### PR TITLE
Row 100 P0: adapter model-id prefix lint + superadmin typecheck fixes

### DIFF
--- a/.claude/rules/backend/ai-adapter.md
+++ b/.claude/rules/backend/ai-adapter.md
@@ -1,0 +1,85 @@
+# AI Adapter 註冊規則
+
+> 新增 / 修改 `apps/superadmin/lib/adapter-config.ts` 之前**必讀**。
+> 違反規則會被 pre-commit hook 擋下（`tools/testing/lint-adapter-model-ids.sh`）。
+
+---
+
+## `model` 欄位前綴規則
+
+`provider` 對應 `model` 前綴的對照：
+
+| provider | `model` 允許的前綴 | 範例 |
+| :-- | :-- | :-- |
+| `opencode` | `opencode/` 或 `openrouter/` | `opencode/grok-code-fast-1` / `openrouter/minimax/minimax-m2.5` |
+| `kilo` | `opencode/` 或 `openrouter/` | `openrouter/qwen/qwen3.6-plus` |
+| `claude` / `codex` / `gemini` | 無限制（CLI 直接收 slug） | `claude-opus-4-7` / `gpt-5.3-codex` / `gemini-3.1-pro-preview` |
+
+### 為什麼必要
+
+`opencode` / `kilo` CLI 會把 model 字串直接丟給 aggregator（OpenRouter）。漏了 `openrouter/` 或 `opencode/` 前綴時 CLI 會 fallback 到 `openrouter/auto`，**不報錯**，實際跑的模型由 OpenRouter 自行決定（通常是 DeepSeek 系 free tier），造成：
+
+- 測試結果不可控（同一 row 不同時間回不同模型）
+- 計費錯誤（走到付費 tier 但管理面板以為走免費 tier）
+- 版本偷換不可見（例：曾經 `minimax/minimax-m2.7` 被靜默路由到 M2.1，詳見 `project-process/dev-logs/dev-ai-settings-adapter-self-report-2026-04-19.md` §2 困難 B）
+
+---
+
+## `provider` 與 `cliCommandTemplate` 對應
+
+| provider | CLI binary | cliCommandTemplate |
+| :-- | :-- | :-- |
+| `claude` | `claude` | `claude -p "<prompt>"` |
+| `codex` | `codex` | `codex exec "<prompt>"` |
+| `gemini` | `agent`（Cursor CLI） | `agent -p "<prompt>"` |
+| `kilo` | `kilo` | `kilo run "<prompt>"` |
+| `opencode` | `opencode` | `opencode run "<prompt>"` |
+
+完整 CLI 指令文件：`docs/Adapter CLIs/`（透過 `/update-cli-docs` 同步）。
+
+---
+
+## id / optionValue 命名慣例
+
+- 格式：`<provider-short>-<vendor>-<model-version>`
+- 只允許 lowercase + 連字號；`.` 版本號轉 `-`（例：`qwen3.6-plus` → `qwen-3-6-plus`）
+- 範例：`claude-opus-4-7`、`opencode-minimax-m2-5`、`kilo-qwen-3-6-plus`
+- `id === optionValue`（目前慣例，可於未來解耦）
+
+---
+
+## Legacy exemptions（暫時豁免清單）
+
+`lint-adapter-model-ids.sh` 內含 `LEGACY_EXEMPTIONS` Set，列出**預存**於 lint 出現前的違規 row，允許短期豁免（印 warning 但不 fail）。
+
+當前豁免清單（截至 2026-04-19）：
+
+- `kilo-dola-seed-2-0-pro`
+- `kilo-qwen-3-6-plus`
+- `opencode-kimi-k2-5`
+- `opencode-glm-5-1`
+- `opencode-qwen-3-6-plus`
+
+**處理流程**：Row 100 P1 baseline self-report 盤點會逐一確認模型真實 id，修正後於**同一個 PR**中：
+
+1. 修正 `apps/superadmin/lib/adapter-config.ts` 的 `model` 欄位
+2. 從 `LEGACY_EXEMPTIONS` 移除該 id
+
+**禁止新增豁免**：新加入的 row 不得寫進 `LEGACY_EXEMPTIONS`，否則失去 lint 抓雷的意義。
+
+---
+
+## 測試
+
+- 單元測試：`apps/superadmin/unit_test/100/lint-adapter-model-ids.test.js`（6 cases：合法 / 違規 / 豁免 / 不受限 provider / mixed）
+- 手動驗證：`bash tools/testing/lint-adapter-model-ids.sh`
+- Manifest 登記：test-manifest.json `id: "100"`
+
+---
+
+## 相關檔案
+
+- 設定表：[apps/superadmin/lib/adapter-config.ts](../../../apps/superadmin/lib/adapter-config.ts)
+- Lint：[tools/testing/lint-adapter-model-ids.sh](../../../tools/testing/lint-adapter-model-ids.sh)
+- Pre-commit hook：[.husky/pre-commit](../../../.husky/pre-commit) step 4
+- Dev log 背景：[project-process/dev-logs/dev-ai-settings-adapter-self-report-2026-04-19.md](../../../project-process/dev-logs/dev-ai-settings-adapter-self-report-2026-04-19.md) §2 困難 B、§4.3、§5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@
 | Supabase 客戶端、RLS、已知陷阱 | `.claude/rules/backend/supabase.md` |
 | Next.js / React 慣例、Badge / Sidebar / 設計 token | `.claude/rules/frontend/react-next.md` |
 | 禁止降級的套件（React 19 / Next 16 等） | `.claude/rules/critical-deps.md` |
+| AI Adapter 註冊（provider/model prefix、id 命名、豁免清單） | `.claude/rules/backend/ai-adapter.md` |
 
 ## 啟動
 

--- a/apps/superadmin/app/api/ai-settings/adapter-runs/route.ts
+++ b/apps/superadmin/app/api/ai-settings/adapter-runs/route.ts
@@ -1,5 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn, type ChildProcessByStdio } from 'node:child_process';
+import type { Readable } from 'node:stream';
+
+/**
+ * The exact subprocess shape produced by `spawn(..., { stdio: ['ignore', 'pipe', 'pipe'] })`:
+ * stdin is null (ignored), stdout and stderr are readable streams. Using
+ * ChildProcessWithoutNullStreams here would falsely claim stdin is also
+ * writable and causes TS2322 on assignment.
+ */
+type AdapterChildProcess = ChildProcessByStdio<null, Readable, Readable>;
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -22,7 +31,7 @@ type ActiveRun = {
   adapterId: string;
   provider: AdapterProvider;
   status: RunStatus;
-  process: ChildProcessWithoutNullStreams;
+  process: AdapterChildProcess;
   command: string;
   logs: string[];
   resultText: string;

--- a/apps/superadmin/app/superadmin/contacts/__tests__/utils.test.ts
+++ b/apps/superadmin/app/superadmin/contacts/__tests__/utils.test.ts
@@ -58,6 +58,8 @@ describe('contacts utils', () => {
               propertyTitle: '台北大安整合案件',
             },
             leadReference: 'LEAD-11111111',
+            assigneeId: null,
+            assigneeName: null,
           },
           {
             id: 'lead-2',
@@ -73,6 +75,8 @@ describe('contacts utils', () => {
               entryPoint: 'pricing-cta',
             },
             leadReference: 'LEAD-22222222',
+            assigneeId: null,
+            assigneeName: null,
           },
         ],
         {

--- a/apps/superadmin/app/superadmin/dashboard/project-progress/components/development-table/prompt-auto-loop.test.ts
+++ b/apps/superadmin/app/superadmin/dashboard/project-progress/components/development-table/prompt-auto-loop.test.ts
@@ -11,6 +11,7 @@ import {
   readStoredAutoPolicy,
   writeStoredExecutionMode,
   writeStoredAutoPolicy,
+  type AutoRunState,
 } from './prompt-auto-loop';
 
 describe('prompt-auto-loop', () => {
@@ -95,9 +96,9 @@ describe('prompt-auto-loop', () => {
   });
 
   it('resets execution state for manual mode', () => {
-    const state = {
+    const state: AutoRunState = {
       ...buildInitialAutoRunState(),
-      phase: 'running' as const,
+      phase: 'running',
       attemptCount: 2,
       consecutiveFailures: 1,
       lastRunId: 'run-99',

--- a/apps/superadmin/components/admin/properties/__tests__/BlogGooglePanel.test.tsx
+++ b/apps/superadmin/components/admin/properties/__tests__/BlogGooglePanel.test.tsx
@@ -47,6 +47,7 @@ function makeBlog(overrides: Partial<BlogPost> = {}): BlogPost {
     blogTargetPlatform: 'google_blogger',
     referenceUrl: null,
     referenceUrlNormalized: null,
+    generationContext: null,
     ...overrides,
   };
 }

--- a/apps/superadmin/components/admin/properties/__tests__/ContractDraftPreviewSection.test.tsx
+++ b/apps/superadmin/components/admin/properties/__tests__/ContractDraftPreviewSection.test.tsx
@@ -2,7 +2,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import JSZip from 'jszip';
 import { ContractDraftPreviewSection } from '../ContractDraftPreviewSection';
-import type { PropertyItem } from '@/lib/types/properties';
+import type {
+  PropertyItem,
+  BuildingTranscriptData,
+  LandTranscriptData,
+} from '@/lib/types/properties';
 
 type MockCloudDraft = {
   id: string;
@@ -61,8 +65,26 @@ async function createMockTemplateDocx() {
   return zip.generateAsync({ type: 'arraybuffer' });
 }
 
+// TranscriptHeader picked up extra metadata fields (checkNumber / documentNumber /
+// dataJurisdiction / issuingAuthority / transcriptNotes). Empty strings are fine
+// here — these tests exercise draft preview rendering, not header content.
+const MOCK_HEADER_EXTRAS = {
+  checkNumber: '',
+  documentNumber: '',
+  dataJurisdiction: '',
+  issuingAuthority: '',
+  transcriptNotes: '',
+};
+
 const MOCK_BUILDING_TRANSCRIPT = {
-  header: { transcriptType: '建物', documentTitle: '大安區仁愛段二小段 01659-000建號', printTime: '2026-03-20', pageInfo: '第1頁', printer: '測試' },
+  header: {
+    transcriptType: '建物',
+    documentTitle: '大安區仁愛段二小段 01659-000建號',
+    printTime: '2026-03-20',
+    pageInfo: '第1頁',
+    printer: '測試',
+    ...MOCK_HEADER_EXTRAS,
+  },
   description: {
     buildingNumber: '01659-000', regDate: '2026-03-20', regReason: '第一次登記', doorAddress: '臺北市大安區仁愛路四段295號3樓',
     landParcelNumber: '100', mainUse: '住家用', mainMaterial: '鋼筋混凝土', totalFloors: '14', totalArea: '99.16',
@@ -73,7 +95,14 @@ const MOCK_BUILDING_TRANSCRIPT = {
 };
 
 const MOCK_LAND_TRANSCRIPT = {
-  header: { transcriptType: '土地', documentTitle: '大安區仁愛段二小段 100地號', printTime: '2026-03-20', pageInfo: '第1頁', printer: '測試' },
+  header: {
+    transcriptType: '土地',
+    documentTitle: '大安區仁愛段二小段 100地號',
+    printTime: '2026-03-20',
+    pageInfo: '第1頁',
+    printer: '測試',
+    ...MOCK_HEADER_EXTRAS,
+  },
   description: {
     landNumber: '0100-000', regDate: '2026-03-20', regReason: '第一次登記', landCategory: '建', grade: '', area: '328.00',
     useZone: '住宅區', useCategory: '住三', announcedValueYear: '2026', announcedValuePerSqm: '300000', notes: '',
@@ -107,8 +136,13 @@ function createProperty(type: 'sale' | 'rental' = 'rental'): PropertyItem {
     livingRooms: 1,
     parkingSpaces: 1,
     createdAt: '2026-03-20T00:00:00.000Z',
-    buildingTranscript: type === 'sale' ? MOCK_BUILDING_TRANSCRIPT : null,
-    landTranscript: type === 'sale' ? MOCK_LAND_TRANSCRIPT : null,
+    updatedAt: '2026-03-20T00:00:00.000Z',
+    // Mock transcripts are intentionally minimal — these tests drive the
+    // contract draft preview UI, not transcript schema coverage. Cast once
+    // to keep the fixtures readable rather than filling every optional
+    // field that the BuildingDescription / OwnershipRecord types accrued.
+    buildingTranscript: type === 'sale' ? (MOCK_BUILDING_TRANSCRIPT as unknown as BuildingTranscriptData) : null,
+    landTranscript: type === 'sale' ? (MOCK_LAND_TRANSCRIPT as unknown as LandTranscriptData) : null,
   };
 }
 

--- a/apps/superadmin/components/admin/properties/__tests__/PropertyBlogGenerator.test.tsx
+++ b/apps/superadmin/components/admin/properties/__tests__/PropertyBlogGenerator.test.tsx
@@ -129,7 +129,7 @@ describe('PropertyBlogGenerator', () => {
     mockGeneratePropertyBlog.mockResolvedValue({
       success: true,
       message: 'ok',
-      blog: null,
+      blog: undefined,
       generationContext: {
         selectedSectionIds: ['basic-info', 'description', 'photos'],
       },
@@ -448,7 +448,7 @@ describe('PropertyBlogGenerator', () => {
     const input = screen.getByPlaceholderText('https://a0405142777.wixsite.com/108-en-lease1');
     await user.clear(input);
     await user.type(input, 'https://example.com/persist-me');
-    await user.click(screen.getByRole('button', { name: '套用', exact: true }));
+    await user.click(screen.getByRole('button', { name: '套用' }));
     await user.click(screen.getByRole('checkbox', { name: '謄本連結' }));
 
     jest.advanceTimersByTime(1000);
@@ -550,7 +550,7 @@ describe('PropertyBlogGenerator', () => {
     const input = screen.getByPlaceholderText('https://a0405142777.wixsite.com/108-en-lease1');
     await user.clear(input);
     await user.type(input, 'https://example.com/ref-style');
-    await user.click(screen.getByRole('button', { name: '套用', exact: true }));
+    await user.click(screen.getByRole('button', { name: '套用' }));
 
     await user.click(screen.getByRole('button', { name: '生成廣告草稿' }));
 

--- a/apps/superadmin/components/admin/properties/__tests__/TranscriptParseSection.prompt-presets.test.tsx
+++ b/apps/superadmin/components/admin/properties/__tests__/TranscriptParseSection.prompt-presets.test.tsx
@@ -43,6 +43,7 @@ const OCR_MODULE = buildOcrParseModule([
 const baseReturn = {
   userId: 'test-user-id',
   modules: [OCR_MODULE] as SavedModule[],
+  prompts: [],
   keys: [],
   models: [],
   evaluations: [],
@@ -53,6 +54,7 @@ const baseReturn = {
   saveKey: jest.fn(),
   deleteKey: jest.fn(),
   validateKey: jest.fn(),
+  revealKey: jest.fn().mockResolvedValue({ plaintext: '', ttlSeconds: 0 }),
   saveModels: jest.fn(),
   saveModule: jest.fn(),
   savePrompt: jest.fn(),

--- a/apps/superadmin/components/admin/properties/__tests__/TranscriptParseSection.prompt.test.tsx
+++ b/apps/superadmin/components/admin/properties/__tests__/TranscriptParseSection.prompt.test.tsx
@@ -67,6 +67,7 @@ const TRANSCRIPT_DOC = {
 const baseReturn = {
   userId: 'test-user-id',
   modules: [OCR_MODULE] as SavedModule[],
+  prompts: [],
   keys: [],
   models: [],
   evaluations: [],
@@ -77,6 +78,7 @@ const baseReturn = {
   saveKey: jest.fn(),
   deleteKey: jest.fn(),
   validateKey: jest.fn(),
+  revealKey: jest.fn().mockResolvedValue({ plaintext: '', ttlSeconds: 0 }),
   saveModels: jest.fn(),
   saveModule: jest.fn(),
   savePrompt: jest.fn(),

--- a/apps/superadmin/components/admin/properties/__tests__/TranscriptParseSection.sync.test.tsx
+++ b/apps/superadmin/components/admin/properties/__tests__/TranscriptParseSection.sync.test.tsx
@@ -63,6 +63,7 @@ const baseReturn = {
   saveKey: jest.fn(),
   deleteKey: jest.fn(),
   validateKey: jest.fn(),
+  revealKey: jest.fn().mockResolvedValue({ plaintext: '', ttlSeconds: 0 }),
   saveModels: jest.fn(),
   saveModule: jest.fn(),
   savePrompt: jest.fn(),

--- a/apps/superadmin/components/ai-settings/__tests__/AgentModelAssignmentPanel.test.tsx
+++ b/apps/superadmin/components/ai-settings/__tests__/AgentModelAssignmentPanel.test.tsx
@@ -125,7 +125,6 @@ function installFetchMock(responses: Response[]) {
     const r = responses[call++] ?? jsonResponse({});
     return Promise.resolve(r);
   });
-  // @ts-expect-error — override global fetch
   global.fetch = fetchMock;
   return fetchMock;
 }

--- a/apps/superadmin/lib/__tests__/transcript-parse-scenario-prompts.test.ts
+++ b/apps/superadmin/lib/__tests__/transcript-parse-scenario-prompts.test.ts
@@ -1,9 +1,16 @@
 import { resolveParsePromptScenario } from '../transcript-parse-scenario-prompts';
+import type {
+  IndependentTitleSaleMode,
+  ParkingTitleRight,
+} from '@/lib/types/properties';
 
 describe('resolveParsePromptScenario', () => {
+  // Using `as const` on the arrays made them readonly tuples; the callee
+  // expects mutable arrays. Use explicit mutable types instead so the fixture
+  // matches the parameter shape.
   const base = {
-    independentTitleSaleModes: ['building_only'] as const,
-    parkingTitleRights: [] as const,
+    independentTitleSaleModes: ['building_only'] as IndependentTitleSaleMode[],
+    parkingTitleRights: [] as ParkingTitleRight[],
     independentBuildingNumberCount: 1,
   };
 

--- a/apps/superadmin/lib/actions/blog.test.ts
+++ b/apps/superadmin/lib/actions/blog.test.ts
@@ -178,7 +178,9 @@ describe('generatePropertyBlog', () => {
     photosQuery.select.mockReturnValue(photosQuery);
     photosQuery.eq.mockReturnValue(photosQuery);
     photosQuery.order.mockReturnValue(photosQuery);
-    photosQuery.then = undefined;
+    // The previous `photosQuery.then = undefined;` line was a no-op (then
+    // isn't a declared field on photosQuery) and failed strict typecheck —
+    // defineProperty below sets up the thenable behaviour anyway.
     Object.defineProperty(photosQuery, 'then', {
       value: (resolve: (value: unknown) => void) => resolve({
         data: [

--- a/apps/superadmin/lib/ai-key-validation/__tests__/kilo-opencode-zen.test.ts
+++ b/apps/superadmin/lib/ai-key-validation/__tests__/kilo-opencode-zen.test.ts
@@ -65,7 +65,10 @@ describe('validateKiloGatewayKey', () => {
     const r = await validateKiloGatewayKey('bad-token', fetchMock);
     expect(r.valid).toBe(false);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0][0]).toBe(`${KILO_GATEWAY_BASE}/models`);
+    // Cast via unknown: jest.fn() with no type arg infers `.mock.calls` as
+    // never[][], which blocks tuple indexing even with a direct cast.
+    const firstCallArgs = fetchMock.mock.calls[0] as unknown as [string, RequestInit?];
+    expect(firstCallArgs[0]).toBe(`${KILO_GATEWAY_BASE}/models`);
   });
 
   it('should call chat probe after GET /models 200 and return valid on probe 200', async () => {

--- a/apps/superadmin/lib/hooks/__tests__/useAISettings.test.tsx
+++ b/apps/superadmin/lib/hooks/__tests__/useAISettings.test.tsx
@@ -40,7 +40,6 @@ describe('useAISettings', () => {
       .mockResolvedValueOnce(jsonResponse({ cache: {} }))
       // validateKey call
       .mockResolvedValueOnce(jsonResponse({ valid: true, message: 'ok', availableModels: [] }));
-    // @ts-expect-error jest replaces global fetch in tests
     global.fetch = fetchMock;
 
     const { result } = renderHook(() => useAISettings());

--- a/apps/superadmin/lib/hooks/__tests__/useAgentAssignments.test.tsx
+++ b/apps/superadmin/lib/hooks/__tests__/useAgentAssignments.test.tsx
@@ -49,7 +49,6 @@ describe('useAgentAssignments', () => {
       if (r instanceof Error) return Promise.reject(r);
       return Promise.resolve(r);
     });
-    // @ts-expect-error — override global fetch
     global.fetch = fetchMock;
     return fetchMock;
   }

--- a/apps/superadmin/lib/utils/__tests__/contract-document-renderer.test.ts
+++ b/apps/superadmin/lib/utils/__tests__/contract-document-renderer.test.ts
@@ -456,6 +456,10 @@ describe('contract-document-renderer', () => {
   });
 
   it('replaces key official sale template payment paragraphs inline when anchors exist', async () => {
+    // Cast rather than `satisfies ContractDraft`: the return of
+    // createSaleDraft() is widened to the ContractDraft union, so spreading
+    // it then adding sale-branch-only fields (ownershipTransferDate etc.)
+    // trips an excess-property check against the lease branch.
     const saleDraft = {
       ...createSaleDraft(),
       contractDate: '2026-03-20',
@@ -467,7 +471,7 @@ describe('contract-document-renderer', () => {
         { label: '完稅款', amount: 7000000, dueDate: '2026-05-01' },
         { label: '交屋款', amount: 12800000, dueDate: '2026-06-30' },
       ],
-    } satisfies ContractDraft;
+    } as ContractDraft;
     const templateDocxBytes = await createOfficialSaleTemplateDocx();
     const buffer = await renderContractDocumentDocx(saleDraft, { templateDocxBytes });
     const zip = await JSZip.loadAsync(buffer);

--- a/apps/superadmin/lib/utils/__tests__/contract-draft-builders.test.ts
+++ b/apps/superadmin/lib/utils/__tests__/contract-draft-builders.test.ts
@@ -34,6 +34,9 @@ function createBuildingTranscript(): BuildingTranscriptData {
       totalArea: '99.17',
       floorLevel: '三層',
       floorArea: '33.05',
+      // BuildingDescription added `mainBuildings: MainBuildingEntry[]` to
+      // support 樓中樓 cases. Empty array keeps this fixture minimal.
+      mainBuildings: [],
       completionDate: '民國99年12月31日',
       annexedBuildings: [],
       commonAreas: [],

--- a/apps/superadmin/test-manifest.json
+++ b/apps/superadmin/test-manifest.json
@@ -154,6 +154,19 @@
       "linkedToolScripts": []
     },
     {
+      "id": "100",
+      "name": "Adapter model id prefix lint",
+      "tier": "pr",
+      "status": "active",
+      "unitPaths": [
+        "apps/superadmin/unit_test/100/lint-adapter-model-ids.test.js"
+      ],
+      "e2ePaths": [],
+      "linkedToolScripts": [
+        "tools/testing/lint-adapter-model-ids.sh"
+      ]
+    },
+    {
       "id": "120",
       "name": "Contract template selector",
       "tier": "nightly",

--- a/apps/superadmin/unit_test/100/README.md
+++ b/apps/superadmin/unit_test/100/README.md
@@ -1,0 +1,36 @@
+# Row 100 測試說明（Adapter model id prefix lint）
+
+## 目的
+
+驗證 `tools/testing/lint-adapter-model-ids.sh` 對 `apps/superadmin/lib/adapter-config.ts` 的 `provider` / `model` 前綴規則稽核邏輯：
+
+1. `provider='opencode' | 'kilo'` 時，`model` 必須以 `opencode/` 或 `openrouter/` 開頭；否則 OpenRouter 會 fallback 至 `openrouter/auto` 導致版本偷換與計費錯亂。
+2. `provider='claude' | 'codex' | 'gemini'` 不受限制。
+3. 預存於 `LEGACY_EXEMPTIONS` 的 id（待 Row 100 P1 baseline 盤點後修正）允許違規但會印 warning；**新加入的違規仍會擋 commit**。
+
+背景：[project-process/dev-logs/dev-ai-settings-adapter-self-report-2026-04-19.md](../../../../project-process/dev-logs/dev-ai-settings-adapter-self-report-2026-04-19.md) §2 困難 B、§5 P0。
+
+## 對應測試
+
+- `apps/superadmin/unit_test/100/lint-adapter-model-ids.test.js` — 含 6 組 fixture：
+  - 合法（Claude/opencode-prefixed/openrouter-prefixed/opencode-native）
+  - 違規（opencode bare vendor / kilo bare vendor）
+  - 不受限 provider（claude/codex/gemini）
+  - Legacy exemption（warn + exit 0）
+  - Mixed exempt + new violation（exit 1 with both messages）
+
+## 執行方式
+
+```bash
+# 獨立執行（無 jest/vitest 依賴）
+node apps/superadmin/unit_test/100/lint-adapter-model-ids.test.js
+
+# 手動對真實 config 跑一次 lint
+bash tools/testing/lint-adapter-model-ids.sh
+```
+
+## 相關檔案
+
+- Lint 腳本：[tools/testing/lint-adapter-model-ids.sh](../../../../tools/testing/lint-adapter-model-ids.sh)
+- Pre-commit hook（step 4）：[.husky/pre-commit](../../../../.husky/pre-commit)
+- 規則：[.claude/rules/backend/ai-adapter.md](../../../../.claude/rules/backend/ai-adapter.md)

--- a/apps/superadmin/unit_test/100/lint-adapter-model-ids.test.js
+++ b/apps/superadmin/unit_test/100/lint-adapter-model-ids.test.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Test harness for tools/testing/lint-adapter-model-ids.sh.
+ *
+ * Exercises the lint with synthetic adapter-config.ts fixtures covering:
+ *   - all-pass (valid prefixes, unaffected providers)
+ *   - plain violation (blocks commit with exit 1)
+ *   - legacy exemption (warns, exits 0)
+ *   - mixed exempted + real violation (still blocks, exemption still warns)
+ *
+ * Runs via plain `node` — no jest/vitest dependency, so it stays executable
+ * even if the main jest config ignores unit_test/100 (it does by default).
+ *
+ * Run:  node apps/superadmin/unit_test/100/lint-adapter-model-ids.test.js
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../../../..');
+const LINT_SCRIPT = path.join(PROJECT_ROOT, 'tools/testing/lint-adapter-model-ids.sh');
+
+function runLint(fixturePath) {
+  const result = spawnSync('bash', [LINT_SCRIPT, fixturePath], {
+    encoding: 'utf8',
+  });
+  return {
+    exit: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function writeFixture(tmpdir, name, entries) {
+  const filePath = path.join(tmpdir, name);
+  const body = `export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [\n${entries
+    .map(
+      (e) => `  {
+    id: '${e.id}',
+    provider: '${e.provider}',
+    model: '${e.model}',
+  },`,
+    )
+    .join('\n')}\n];\n`;
+  fs.writeFileSync(filePath, body, 'utf8');
+  return filePath;
+}
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+function assert(cond, message) {
+  if (!cond) throw new Error(`assertion failed: ${message}`);
+}
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-adapter-'));
+
+test('all valid rows exit 0 and print OK', () => {
+  const fixture = writeFixture(tmpRoot, 'all-valid.ts', [
+    { id: 'claude-opus-4-7', provider: 'claude', model: 'claude-opus-4-7' },
+    { id: 'opencode-minimax-m2-5', provider: 'opencode', model: 'openrouter/minimax/minimax-m2.5' },
+    { id: 'kilo-minimax-m2-5', provider: 'kilo', model: 'openrouter/minimax/minimax-m2.5' },
+    { id: 'opencode-native', provider: 'opencode', model: 'opencode/grok-code' },
+  ]);
+  const { exit, stdout, stderr } = runLint(fixture);
+  assert(exit === 0, `expected exit 0, got ${exit}. stderr=${stderr}`);
+  assert(stdout.includes('adapter entries OK'), `expected OK banner, got stdout=${stdout}`);
+  assert(!stderr.includes('violation(s)'), `unexpected violation banner: ${stderr}`);
+});
+
+test('bare vendor id on opencode provider fails with exit 1', () => {
+  const fixture = writeFixture(tmpRoot, 'opencode-no-prefix.ts', [
+    { id: 'opencode-bad', provider: 'opencode', model: 'moonshotai/kimi-k2.5' },
+  ]);
+  const { exit, stderr } = runLint(fixture);
+  assert(exit === 1, `expected exit 1, got ${exit}`);
+  assert(stderr.includes('opencode-bad'), `expected id in stderr, got ${stderr}`);
+  assert(stderr.includes('must start with'), `expected fix hint, got ${stderr}`);
+});
+
+test('bare vendor id on kilo provider fails with exit 1', () => {
+  const fixture = writeFixture(tmpRoot, 'kilo-no-prefix.ts', [
+    { id: 'kilo-bad', provider: 'kilo', model: 'qwen/qwen3.6-plus' },
+  ]);
+  const { exit, stderr } = runLint(fixture);
+  assert(exit === 1, `expected exit 1, got ${exit}`);
+  assert(stderr.includes('kilo-bad'), `expected id in stderr, got ${stderr}`);
+});
+
+test('claude/codex/gemini providers are not constrained', () => {
+  const fixture = writeFixture(tmpRoot, 'other-providers.ts', [
+    { id: 'codex-gpt-5-3', provider: 'codex', model: 'gpt-5.3-codex' },
+    { id: 'gemini-3-1', provider: 'gemini', model: 'gemini-3.1-pro-preview' },
+    { id: 'claude-opus-4-7', provider: 'claude', model: 'claude-opus-4-7' },
+  ]);
+  const { exit, stdout } = runLint(fixture);
+  assert(exit === 0, `expected exit 0, got ${exit}`);
+  assert(stdout.includes('adapter entries OK'));
+});
+
+test('legacy-exempted id warns but exits 0', () => {
+  const fixture = writeFixture(tmpRoot, 'legacy-exempt.ts', [
+    { id: 'claude-opus-4-7', provider: 'claude', model: 'claude-opus-4-7' },
+    { id: 'opencode-kimi-k2-5', provider: 'opencode', model: 'moonshotai/kimi-k2.5' },
+  ]);
+  const { exit, stdout, stderr } = runLint(fixture);
+  assert(exit === 0, `expected exit 0 for legacy exemption, got ${exit}. stderr=${stderr}`);
+  assert(
+    stderr.includes('legacy exemption'),
+    `expected exemption warning, got stderr=${stderr}`,
+  );
+  assert(stderr.includes('opencode-kimi-k2-5'));
+  assert(stdout.includes('adapter entries OK'));
+});
+
+test('new violation still blocks even when exempted rows present', () => {
+  const fixture = writeFixture(tmpRoot, 'mixed.ts', [
+    { id: 'opencode-kimi-k2-5', provider: 'opencode', model: 'moonshotai/kimi-k2.5' },
+    { id: 'opencode-newbad', provider: 'opencode', model: 'vendor/something' },
+  ]);
+  const { exit, stderr } = runLint(fixture);
+  assert(exit === 1, `expected exit 1 when a non-exempt violation exists, got ${exit}`);
+  assert(stderr.includes('opencode-newbad'), `expected new violation reported: ${stderr}`);
+  assert(stderr.includes('legacy exemption'), `expected exemption warning still printed: ${stderr}`);
+});
+
+let failed = 0;
+for (const t of tests) {
+  try {
+    t.fn();
+    console.log(`  ✓ ${t.name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  ✗ ${t.name}`);
+    console.error(`    ${err.message}`);
+  }
+}
+
+fs.rmSync(tmpRoot, { recursive: true, force: true });
+
+console.log('');
+if (failed > 0) {
+  console.error(`${failed}/${tests.length} test(s) failed`);
+  process.exit(1);
+}
+console.log(`${tests.length}/${tests.length} tests passed`);
+process.exit(0);

--- a/tools/testing/lint-adapter-model-ids.sh
+++ b/tools/testing/lint-adapter-model-ids.sh
@@ -11,6 +11,10 @@
 #   the full <provider>/<vendor>/<model> slug; a bare vendor id silently falls
 #   back to `openrouter/auto`, which masks version drift.
 #
+# Legacy exemptions: a short allowlist of ids that predate this lint is
+# tolerated with a warning — their correct replacement model id is blocked on
+# the Row 100 P1 baseline self-report audit. New rows get no such grace.
+#
 # Usage:
 #   tools/testing/lint-adapter-model-ids.sh [path/to/adapter-config.ts]
 #
@@ -93,7 +97,23 @@ if (entries.length === 0) {
 
 const PROVIDERS_REQUIRING_PREFIX = new Set(['opencode', 'kilo']);
 const ALLOWED_PREFIXES = ['opencode/', 'openrouter/'];
+
+// Temporary exemptions — rows that predate this lint and whose correct
+// replacement model id is blocked on the Row 100 P1 baseline self-report
+// audit (see §5 P0/P1 of the 2026-04-19 dev log). Each entry should be
+// removed in the same PR that fixes the row's model id.
+// DO NOT add new entries here without explicit approval — the point of
+// this lint is to stop new rows from landing without a prefix.
+const LEGACY_EXEMPTIONS = new Set([
+  'kilo-dola-seed-2-0-pro',
+  'kilo-qwen-3-6-plus',
+  'opencode-kimi-k2-5',
+  'opencode-glm-5-1',
+  'opencode-qwen-3-6-plus',
+]);
+
 const violations = [];
+const exempted = [];
 
 function lineOf(text, offset) {
   return text.slice(0, offset).split('\n').length;
@@ -121,17 +141,31 @@ for (const entry of entries) {
   if (!PROVIDERS_REQUIRING_PREFIX.has(provider)) continue;
   if (ALLOWED_PREFIXES.some((p) => model.startsWith(p))) continue;
 
-  violations.push({
+  const record = {
     id,
     provider,
     model,
     line,
     reason: `model must start with one of: ${ALLOWED_PREFIXES.join(', ')}`,
-  });
+  };
+  if (LEGACY_EXEMPTIONS.has(id)) {
+    exempted.push(record);
+  } else {
+    violations.push(record);
+  }
+}
+
+if (exempted.length > 0) {
+  console.warn(
+    `⚠️  lint-adapter-model-ids: ${exempted.length} legacy exemption(s) still pending Row 100 P1 audit:`,
+  );
+  for (const v of exempted) {
+    console.warn(`  - [${v.id}] (line ${v.line}) provider='${v.provider}' model='${v.model}'`);
+  }
 }
 
 if (violations.length === 0) {
-  console.log(`✅ lint-adapter-model-ids: ${entries.length} adapter entries OK`);
+  console.log(`✅ lint-adapter-model-ids: ${entries.length - exempted.length} adapter entries OK`);
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

- **Row 100 P0 – adapter model-id prefix lint** (commits `23366a8`, `b8d3a4f`): pre-commit hook blocks adapter rows whose `provider` is `opencode` / `kilo` from landing without an `opencode/` or `openrouter/` prefix — the exact regression that let OpenRouter silently route `minimax/minimax-m2.7` to M2.1 for weeks.
- **Legacy exemption allowlist**: 5 pre-existing violating rows are warned-but-tolerated pending the Row 100 P1 baseline self-report audit. New rows get no such grace.
- **Unit tests**: 6 fixture cases under `apps/superadmin/unit_test/100/` (plain Node, no jest/vitest dep) covering pass / fail / exemption / mixed scenarios.
- **Rules doc**: `.claude/rules/backend/ai-adapter.md` documenting the prefix rule, id naming, exemption policy, and the `minimax-m2.7 → M2.1` incident context.
- **Superadmin typecheck fix** (commit `45fa783`): clears 29 pre-existing TS errors across 17 test files, matching the branch's original scope.

Background: `project-process/dev-logs/dev-ai-settings-adapter-self-report-2026-04-19.md` §2 困難 B / §4.3 / §5.

## Test plan

- [x] `bash tools/testing/lint-adapter-model-ids.sh` → exit 0 with 5 legacy-exempt warnings
- [x] `node apps/superadmin/unit_test/100/lint-adapter-model-ids.test.js` → 6/6 tests pass
- [x] `bash tools/testing/validate-test-manifest.sh` → 20 entries validated
- [ ] CI typecheck passes on superadmin (depends on 45fa783)
- [ ] Reviewer: confirm the `LEGACY_EXEMPTIONS` Set is acceptable until P1 audit
- [ ] Reviewer: verify pre-commit hook fires when `adapter-config.ts` is touched

## Next (separate PR)

Row 100 P1: baseline self-report audit across all `status='planned'` adapters → derive real replacement model ids for the 5 exempted rows → remove each id from `LEGACY_EXEMPTIONS` in the same PR that fixes it. See `project-process/dev-logs/dev-ai-settings-adapter-self-report-2026-04-19.md` §5 P0/P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)