### PR TITLE
feat(superadmin): Supabase dashboard 擴充（SQL runner + migration 歷史 + DB health + 手動備份）

### DIFF
--- a/apps/superadmin/app/api/supabase/sql/route.ts
+++ b/apps/superadmin/app/api/supabase/sql/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createAdminClient } from '@/utils/supabase/admin';
+
+const MAX_LIMIT = 200;
+const FORBIDDEN_SQL = /(insert|update|delete|drop|alter|create|grant|revoke|truncate|call|execute|copy)\b/i;
+const SUPPORTED_SELECT = /^select\s+([\w*\s,\"]+)\s+from\s+([a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)?)\s*(?:limit\s+(\d+))?\s*;?$/i;
+
+interface ParsedSelect {
+  columns: string;
+  schema: string;
+  table: string;
+  limit: number;
+}
+
+function parseSelectQuery(raw: string): ParsedSelect | null {
+  const query = raw.trim();
+  if (!query || FORBIDDEN_SQL.test(query)) return null;
+
+  const match = query.match(SUPPORTED_SELECT);
+  if (!match) return null;
+
+  const [, rawColumns, rawTable, rawLimit] = match;
+  const [schemaCandidate, tableCandidate] = rawTable.includes('.')
+    ? rawTable.split('.', 2)
+    : ['public', rawTable];
+
+  const columns = rawColumns
+    .split(',')
+    .map((column) => column.trim())
+    .filter(Boolean)
+    .join(',');
+
+  const limitNum = Number.parseInt(rawLimit ?? '50', 10);
+  const limit = Number.isFinite(limitNum)
+    ? Math.max(1, Math.min(MAX_LIMIT, limitNum))
+    : 50;
+
+  return {
+    columns: columns || '*',
+    schema: schemaCandidate,
+    table: tableCandidate,
+    limit,
+  };
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as { query?: string };
+    const query = body.query ?? '';
+    const parsed = parseSelectQuery(query);
+
+    if (!parsed) {
+      return NextResponse.json(
+        {
+          error:
+            'Only SELECT is allowed. Supported syntax: SELECT <columns> FROM [schema.]table [LIMIT n]',
+        },
+        { status: 400 },
+      );
+    }
+
+    const admin = createAdminClient();
+    const fromBuilder =
+      parsed.schema === 'public'
+        ? admin.from(parsed.table)
+        : admin.schema(parsed.schema).from(parsed.table);
+
+    const { data, error } = await fromBuilder.select(parsed.columns).limit(parsed.limit);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({
+      columns: parsed.columns,
+      table: `${parsed.schema}.${parsed.table}`,
+      limit: parsed.limit,
+      rowCount: Array.isArray(data) ? data.length : 0,
+      rows: data ?? [],
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unknown query error' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/superadmin/app/superadmin/dashboard/supabase/SupabaseDashboardClient.tsx
+++ b/apps/superadmin/app/superadmin/dashboard/supabase/SupabaseDashboardClient.tsx
@@ -1,15 +1,21 @@
 'use client';
 
+import { useEffect, useMemo, useState } from 'react';
 import {
   Database,
   ExternalLink,
   Activity,
   Shield,
-  Users,
   Table2,
   CheckCircle,
   XCircle,
   RefreshCw,
+  Clock3,
+  Network,
+  Play,
+  Download,
+  FileClock,
+  TerminalSquare,
 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 
@@ -18,7 +24,7 @@ interface TableStat {
   tablename: string;
   n_live_tup: number;
   n_dead_tup: number;
-  last_autovacuum: string | null;
+  last_updated_at: string | null;
 }
 
 interface RLSPolicy {
@@ -29,20 +35,54 @@ interface RLSPolicy {
   roles: string[];
 }
 
+interface MigrationHistoryItem {
+  version: string;
+  appliedAt: string | null;
+  status: 'applied' | 'pending';
+}
+
+interface BackupItem {
+  id: string;
+  filename: string;
+  size: number;
+  created_at?: string;
+}
+
+interface SqlResult {
+  columns: string;
+  table: string;
+  limit: number;
+  rowCount: number;
+  rows: Array<Record<string, unknown>>;
+}
+
 interface SupabaseDashboardClientProps {
   healthy: boolean;
+  latencyMs: number | null;
+  connectionCount: number | null;
   tablestats: TableStat[];
   rlsPolicies: RLSPolicy[];
   userCount: number;
+  migrationHistory: MigrationHistoryItem[];
   projectRef: string;
   supabaseUrl: string;
 }
 
+function formatDateTime(raw: string | null | undefined): string {
+  if (!raw) return 'N/A';
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return raw;
+  return date.toLocaleString();
+}
+
 export default function SupabaseDashboardClient({
   healthy,
+  latencyMs,
+  connectionCount,
   tablestats,
   rlsPolicies,
   userCount,
+  migrationHistory,
   projectRef,
   supabaseUrl,
 }: SupabaseDashboardClientProps) {
@@ -50,18 +90,97 @@ export default function SupabaseDashboardClient({
     ? `https://supabase.com/dashboard/project/${projectRef}`
     : 'http://localhost:54323/project/default';
 
+  const [sqlQuery, setSqlQuery] = useState('SELECT * FROM iam_groups LIMIT 20');
+  const [sqlLoading, setSqlLoading] = useState(false);
+  const [sqlError, setSqlError] = useState<string | null>(null);
+  const [sqlResult, setSqlResult] = useState<SqlResult | null>(null);
+
+  const [backupLoading, setBackupLoading] = useState(false);
+  const [backupError, setBackupError] = useState<string | null>(null);
+  const [backups, setBackups] = useState<BackupItem[]>([]);
+
+  const sortedTableStats = useMemo(
+    () => [...tablestats].sort((a, b) => b.n_live_tup - a.n_live_tup),
+    [tablestats],
+  );
+
+  async function refreshBackups() {
+    setBackupError(null);
+    try {
+      const response = await fetch('/api/backup', { cache: 'no-store' });
+      const payload = (await response.json()) as { backups?: BackupItem[]; error?: string };
+      if (!response.ok) {
+        throw new Error(payload.error ?? 'Failed to load backups');
+      }
+      setBackups(payload.backups ?? []);
+    } catch (error) {
+      setBackupError(error instanceof Error ? error.message : 'Failed to load backups');
+    }
+  }
+
+  useEffect(() => {
+    void refreshBackups();
+  }, []);
+
+  async function runSqlQuery() {
+    setSqlLoading(true);
+    setSqlError(null);
+    setSqlResult(null);
+
+    try {
+      const response = await fetch('/api/supabase/sql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: sqlQuery }),
+      });
+
+      const payload = (await response.json()) as SqlResult & { error?: string };
+      if (!response.ok) {
+        throw new Error(payload.error ?? 'SQL query failed');
+      }
+
+      setSqlResult(payload);
+    } catch (error) {
+      setSqlError(error instanceof Error ? error.message : 'SQL query failed');
+    } finally {
+      setSqlLoading(false);
+    }
+  }
+
+  async function runManualBackup() {
+    setBackupLoading(true);
+    setBackupError(null);
+
+    try {
+      const response = await fetch('/api/backup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ trigger: 'manual_from_supabase_dashboard' }),
+      });
+
+      const payload = (await response.json()) as { error?: string };
+      if (!response.ok) {
+        throw new Error(payload.error ?? 'Backup failed');
+      }
+
+      await refreshBackups();
+    } catch (error) {
+      setBackupError(error instanceof Error ? error.message : 'Backup failed');
+    } finally {
+      setBackupLoading(false);
+    }
+  }
+
   return (
     <div className="p-8 max-w-7xl mx-auto space-y-6 bg-[#1A1A1A] min-h-screen text-white">
-      {/* Header */}
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-3">
             <Database className="h-7 w-7 text-emerald-400" />
             Supabase 資料庫管理
           </h1>
-          {supabaseUrl && (
-            <p className="text-gray-500 text-xs mt-1 font-mono">{supabaseUrl}</p>
-          )}
+          {supabaseUrl && <p className="text-gray-500 text-xs mt-1 font-mono">{supabaseUrl}</p>}
+          <p className="text-gray-500 text-xs mt-1">IAM 使用者數: {userCount}</p>
         </div>
         <div className="flex gap-3">
           <button
@@ -83,8 +202,7 @@ export default function SupabaseDashboardClient({
         </div>
       </div>
 
-      {/* Status Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <Card className="bg-[#2A2A2A] border-[#333333]">
           <CardContent className="p-5 flex items-center gap-4">
             <div className={`p-3 rounded-lg ${healthy ? 'bg-emerald-500/10' : 'bg-red-500/10'}`}>
@@ -120,14 +238,37 @@ export default function SupabaseDashboardClient({
             </div>
           </CardContent>
         </Card>
+
+        <Card className="bg-[#2A2A2A] border-[#333333]">
+          <CardContent className="p-5 flex items-center gap-4">
+            <div className="p-3 rounded-lg bg-amber-500/10">
+              <Clock3 className="w-5 h-5 text-amber-400" />
+            </div>
+            <div>
+              <p className="text-sm text-gray-400">延遲</p>
+              <p className="text-2xl font-bold text-white mt-1">{latencyMs ?? 'N/A'}{latencyMs !== null ? 'ms' : ''}</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-[#2A2A2A] border-[#333333]">
+          <CardContent className="p-5 flex items-center gap-4">
+            <div className="p-3 rounded-lg bg-violet-500/10">
+              <Network className="w-5 h-5 text-violet-400" />
+            </div>
+            <div>
+              <p className="text-sm text-gray-400">連線數</p>
+              <p className="text-2xl font-bold text-white mt-1">{connectionCount ?? 'N/A'}</p>
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
-      {/* Table Stats */}
       <Card className="bg-[#2A2A2A] border-[#333333]">
         <CardHeader className="border-b border-[#333333] pb-4">
           <CardTitle className="text-white text-base flex items-center gap-2">
             <Table2 className="w-4 h-4 text-blue-400" />
-            資料表記錄數
+            資料表記錄數與最後更新時間
           </CardTitle>
         </CardHeader>
         <CardContent className="p-0">
@@ -137,28 +278,30 @@ export default function SupabaseDashboardClient({
                 <tr>
                   <th className="px-4 py-3">Schema</th>
                   <th className="px-4 py-3">資料表名稱</th>
-                  <th className="px-4 py-3 text-right">記錄數（估計）</th>
+                  <th className="px-4 py-3 text-right">記錄數</th>
+                  <th className="px-4 py-3">最後更新</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-[#333333]">
-                {tablestats.length === 0 ? (
+                {sortedTableStats.length === 0 ? (
                   <tr>
-                    <td colSpan={3} className="px-4 py-8 text-center text-gray-500">
+                    <td colSpan={4} className="px-4 py-8 text-center text-gray-500">
                       無法取得資料表資訊
                     </td>
                   </tr>
                 ) : (
-                  tablestats
-                    .sort((a, b) => b.n_live_tup - a.n_live_tup)
-                    .map(t => (
-                      <tr key={t.tablename} className="hover:bg-[#333333]/50 transition-colors">
-                        <td className="px-4 py-3 text-gray-500 text-xs">{t.schemaname}</td>
-                        <td className="px-4 py-3 font-mono text-sm text-white">{t.tablename}</td>
-                        <td className="px-4 py-3 text-right text-gray-300">
-                          {t.n_live_tup.toLocaleString()}
-                        </td>
-                      </tr>
-                    ))
+                  sortedTableStats.map((tableStat) => (
+                    <tr key={tableStat.tablename} className="hover:bg-[#333333]/50 transition-colors">
+                      <td className="px-4 py-3 text-gray-500 text-xs">{tableStat.schemaname}</td>
+                      <td className="px-4 py-3 font-mono text-sm text-white">{tableStat.tablename}</td>
+                      <td className="px-4 py-3 text-right text-gray-300">
+                        {tableStat.n_live_tup.toLocaleString()}
+                      </td>
+                      <td className="px-4 py-3 text-gray-400 text-xs">
+                        {formatDateTime(tableStat.last_updated_at)}
+                      </td>
+                    </tr>
+                  ))
                 )}
               </tbody>
             </table>
@@ -166,7 +309,187 @@ export default function SupabaseDashboardClient({
         </CardContent>
       </Card>
 
-      {/* RLS Policies (if available) */}
+      <Card className="bg-[#2A2A2A] border-[#333333]">
+        <CardHeader className="border-b border-[#333333] pb-4">
+          <CardTitle className="text-white text-base flex items-center gap-2">
+            <TerminalSquare className="w-4 h-4 text-emerald-400" />
+            SQL 查詢（僅 SELECT）
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 pt-5">
+          <textarea
+            value={sqlQuery}
+            onChange={(event) => setSqlQuery(event.target.value)}
+            rows={4}
+            className="w-full rounded-md bg-[#1A1A1A] border border-[#333333] text-sm p-3 font-mono text-gray-200"
+            placeholder="SELECT * FROM iam_groups LIMIT 20"
+          />
+          <div className="flex items-center gap-3">
+            <button
+              onClick={runSqlQuery}
+              disabled={sqlLoading}
+              className="inline-flex items-center gap-2 rounded-md bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 px-4 py-2 text-sm"
+            >
+              <Play className="w-4 h-4" />
+              {sqlLoading ? '執行中...' : '執行查詢'}
+            </button>
+            <p className="text-xs text-gray-500">支援格式: SELECT &lt;columns&gt; FROM [schema.]table [LIMIT n]</p>
+          </div>
+
+          {sqlError && <p className="text-sm text-red-400">{sqlError}</p>}
+
+          {sqlResult && (
+            <div className="space-y-3">
+              <p className="text-xs text-gray-400">
+                table: <span className="font-mono text-gray-300">{sqlResult.table}</span> | rows: {sqlResult.rowCount}
+              </p>
+              <div className="overflow-x-auto border border-[#333333] rounded-md">
+                <table className="w-full text-xs">
+                  <thead className="bg-[#1A1A1A] border-b border-[#333333] text-gray-400">
+                    <tr>
+                      {Object.keys(sqlResult.rows[0] ?? {}).map((column) => (
+                        <th key={column} className="px-3 py-2 text-left font-mono">
+                          {column}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-[#333333]">
+                    {sqlResult.rows.map((row, index) => (
+                      <tr key={index}>
+                        {Object.entries(row).map(([column, value]) => (
+                          <td key={`${index}-${column}`} className="px-3 py-2 text-gray-300 align-top">
+                            {typeof value === 'object' ? JSON.stringify(value) : String(value)}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="bg-[#2A2A2A] border-[#333333]">
+        <CardHeader className="border-b border-[#333333] pb-4">
+          <CardTitle className="text-white text-base flex items-center gap-2">
+            <FileClock className="w-4 h-4 text-cyan-400" />
+            Migration 歷史
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm text-left">
+              <thead className="border-b border-[#333333] text-gray-400 text-xs">
+                <tr>
+                  <th className="px-4 py-3">版本</th>
+                  <th className="px-4 py-3">狀態</th>
+                  <th className="px-4 py-3">執行時間</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[#333333]">
+                {migrationHistory.length === 0 ? (
+                  <tr>
+                    <td colSpan={3} className="px-4 py-8 text-center text-gray-500">
+                      無 migration 資訊
+                    </td>
+                  </tr>
+                ) : (
+                  migrationHistory.slice(0, 50).map((item) => (
+                    <tr key={item.version}>
+                      <td className="px-4 py-3 font-mono text-xs text-gray-200">{item.version}</td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`inline-flex rounded-full px-2 py-1 text-xs ${
+                            item.status === 'applied'
+                              ? 'bg-emerald-500/15 text-emerald-300'
+                              : 'bg-amber-500/15 text-amber-300'
+                          }`}
+                        >
+                          {item.status === 'applied' ? '已執行' : '待執行'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-gray-400 text-xs">{formatDateTime(item.appliedAt)}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="bg-[#2A2A2A] border-[#333333]">
+        <CardHeader className="border-b border-[#333333] pb-4">
+          <CardTitle className="text-white text-base flex items-center gap-2">
+            <Download className="w-4 h-4 text-amber-400" />
+            手動備份與下載
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 pt-5">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={runManualBackup}
+              disabled={backupLoading}
+              className="inline-flex items-center gap-2 rounded-md bg-amber-600 hover:bg-amber-700 disabled:opacity-50 px-4 py-2 text-sm"
+            >
+              <Play className="w-4 h-4" />
+              {backupLoading ? '備份中...' : '觸發手動備份'}
+            </button>
+            <button
+              onClick={() => void refreshBackups()}
+              className="inline-flex items-center gap-2 rounded-md border border-[#333333] px-3 py-2 text-sm text-gray-300 hover:text-white"
+            >
+              <RefreshCw className="w-4 h-4" />
+              重新整理備份列表
+            </button>
+          </div>
+
+          {backupError && <p className="text-sm text-red-400">{backupError}</p>}
+
+          <div className="overflow-x-auto border border-[#333333] rounded-md">
+            <table className="w-full text-sm text-left">
+              <thead className="bg-[#1A1A1A] border-b border-[#333333] text-gray-400 text-xs">
+                <tr>
+                  <th className="px-4 py-3">檔案</th>
+                  <th className="px-4 py-3">建立時間</th>
+                  <th className="px-4 py-3">大小 (bytes)</th>
+                  <th className="px-4 py-3">下載</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[#333333]">
+                {backups.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="px-4 py-8 text-center text-gray-500">
+                      尚無備份檔案
+                    </td>
+                  </tr>
+                ) : (
+                  backups.slice(0, 20).map((backup) => (
+                    <tr key={backup.id}>
+                      <td className="px-4 py-3 font-mono text-xs text-gray-300">{backup.filename}</td>
+                      <td className="px-4 py-3 text-gray-400 text-xs">{formatDateTime(backup.created_at)}</td>
+                      <td className="px-4 py-3 text-gray-400 text-xs">{backup.size.toLocaleString()}</td>
+                      <td className="px-4 py-3">
+                        <a
+                          href={`/api/backup/${backup.id}`}
+                          className="inline-flex items-center gap-2 text-xs text-emerald-300 hover:text-emerald-200"
+                        >
+                          <Download className="w-3 h-3" />
+                          下載
+                        </a>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
       {rlsPolicies.length > 0 && (
         <Card className="bg-[#2A2A2A] border-[#333333]">
           <CardHeader className="border-b border-[#333333] pb-4">
@@ -187,13 +510,13 @@ export default function SupabaseDashboardClient({
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-[#333333]">
-                  {rlsPolicies.map((p, i) => (
-                    <tr key={i} className="hover:bg-[#333333]/50 transition-colors">
-                      <td className="px-4 py-3 font-mono text-xs text-white">{p.tablename}</td>
-                      <td className="px-4 py-3 text-gray-300 text-xs">{p.policyname}</td>
-                      <td className="px-4 py-3 text-blue-400 text-xs">{p.cmd}</td>
+                  {rlsPolicies.map((policy, index) => (
+                    <tr key={index} className="hover:bg-[#333333]/50 transition-colors">
+                      <td className="px-4 py-3 font-mono text-xs text-white">{policy.tablename}</td>
+                      <td className="px-4 py-3 text-gray-300 text-xs">{policy.policyname}</td>
+                      <td className="px-4 py-3 text-blue-400 text-xs">{policy.cmd}</td>
                       <td className="px-4 py-3 text-gray-400 text-xs">
-                        {Array.isArray(p.roles) ? p.roles.join(', ') : String(p.roles)}
+                        {Array.isArray(policy.roles) ? policy.roles.join(', ') : String(policy.roles)}
                       </td>
                     </tr>
                   ))}
@@ -204,7 +527,6 @@ export default function SupabaseDashboardClient({
         </Card>
       )}
 
-      {/* Quick Links */}
       <Card className="bg-[#2A2A2A] border-[#333333]">
         <CardHeader className="pb-3">
           <CardTitle className="text-white text-base">Supabase 快速連結</CardTitle>
@@ -220,7 +542,7 @@ export default function SupabaseDashboardClient({
               { label: 'Logs', path: '/logs/explorer' },
               { label: 'Backups', path: '/database/backups/scheduled' },
               { label: 'Advisors', path: '/advisors' },
-            ].map(link => (
+            ].map((link) => (
               <a
                 key={link.label}
                 href={`${dashboardUrl}${link.path}`}

--- a/apps/superadmin/app/superadmin/dashboard/supabase/page.tsx
+++ b/apps/superadmin/app/superadmin/dashboard/supabase/page.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from 'react';
-import { ExternalLink, Database } from 'lucide-react';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Database } from 'lucide-react';
 import { createAdminClient } from '@/utils/supabase/admin';
 import SupabaseDashboardClient from './SupabaseDashboardClient';
 
@@ -10,7 +12,7 @@ interface TableStat {
   tablename: string;
   n_live_tup: number;
   n_dead_tup: number;
-  last_autovacuum: string | null;
+  last_updated_at: string | null;
 }
 
 interface RLSPolicy {
@@ -21,63 +23,209 @@ interface RLSPolicy {
   roles: string[];
 }
 
+interface MigrationHistoryItem {
+  version: string;
+  appliedAt: string | null;
+  status: 'applied' | 'pending';
+}
+
+const KNOWN_TABLES = [
+  'iam_roles',
+  'iam_groups',
+  'iam_user_group_memberships',
+  'ai_performance_metrics',
+  'web_analytics',
+  'behavior_logs',
+  'web_vitals',
+  'user_page_settings',
+  'module_model_assignments',
+];
+
+const TIMESTAMP_CANDIDATES = ['updated_at', 'created_at', 'inserted_at'];
+
+async function getTableLastUpdatedAt(
+  supabase: ReturnType<typeof createAdminClient>,
+  tableName: string,
+): Promise<string | null> {
+  for (const columnName of TIMESTAMP_CANDIDATES) {
+    const { data, error } = await supabase
+      .from(tableName)
+      .select(columnName)
+      .not(columnName, 'is', null)
+      .order(columnName, { ascending: false })
+      .limit(1);
+
+    if (error) continue;
+    const value = data?.[0]?.[columnName as keyof (typeof data)[0]];
+    if (typeof value === 'string' && value) return value;
+  }
+
+  return null;
+}
+
+async function readLocalMigrationVersions(): Promise<string[]> {
+  const candidates = [
+    path.resolve(process.cwd(), 'supabase/migrations'),
+    path.resolve(process.cwd(), '../../supabase/migrations'),
+    path.resolve(process.cwd(), '../supabase/migrations'),
+  ];
+
+  for (const dir of candidates) {
+    try {
+      const files = await fs.readdir(dir);
+      const versions = files
+        .filter((filename) => /^\d{14}.*\.sql$/.test(filename))
+        .map((filename) => filename.match(/^(\d{14})/)?.[1])
+        .filter((version): version is string => Boolean(version))
+        .sort((a, b) => b.localeCompare(a));
+
+      if (versions.length > 0) return versions;
+    } catch {
+      // Keep trying fallback directories.
+    }
+  }
+
+  return [];
+}
+
+async function getMigrationHistory(
+  supabase: ReturnType<typeof createAdminClient>,
+): Promise<MigrationHistoryItem[]> {
+  const localVersions = await readLocalMigrationVersions();
+
+  const migrationSchemaClient =
+    typeof (supabase as { schema?: unknown }).schema === 'function'
+      ? (supabase as { schema: (schemaName: string) => ReturnType<typeof createAdminClient> }).schema(
+          'supabase_migrations',
+        )
+      : supabase;
+
+  const { data: appliedRows } = await migrationSchemaClient
+    .from('schema_migrations')
+    .select('version, inserted_at')
+    .order('version', { ascending: false })
+    .limit(200);
+
+  const appliedMap = new Map<string, string | null>();
+  for (const row of appliedRows ?? []) {
+    const version = String((row as { version?: unknown }).version ?? '');
+    if (!version) continue;
+    const insertedAt =
+      typeof (row as { inserted_at?: unknown }).inserted_at === 'string'
+        ? ((row as { inserted_at?: string }).inserted_at ?? null)
+        : null;
+    appliedMap.set(version, insertedAt);
+  }
+
+  if (localVersions.length === 0) {
+    return Array.from(appliedMap.entries()).map(([version, appliedAt]) => ({
+      version,
+      appliedAt,
+      status: 'applied',
+    }));
+  }
+
+  return localVersions.map((version) => ({
+    version,
+    appliedAt: appliedMap.get(version) ?? null,
+    status: appliedMap.has(version) ? 'applied' : 'pending',
+  }));
+}
+
+async function getConnectionCount(
+  supabase: ReturnType<typeof createAdminClient>,
+): Promise<number | null> {
+  try {
+    if (typeof (supabase as { schema?: unknown }).schema !== 'function') return null;
+
+    const pgCatalogClient = (
+      supabase as { schema: (schemaName: string) => ReturnType<typeof createAdminClient> }
+    ).schema('pg_catalog');
+
+    const { count, error } = await pgCatalogClient
+      .from('pg_stat_activity')
+      .select('pid', { count: 'exact', head: true });
+
+    if (error) return null;
+    return count ?? null;
+  } catch {
+    return null;
+  }
+}
+
 async function getDatabaseStats() {
   const supabase = createAdminClient();
   let healthy = false;
+  let latencyMs: number | null = null;
+  let connectionCount: number | null = null;
   let tablestats: TableStat[] = [];
   let rlsPolicies: RLSPolicy[] = [];
   let userCount = 0;
+  let migrationHistory: MigrationHistoryItem[] = [];
 
   try {
-    // Health check: simple ping
+    const start = Date.now();
     const { error: pingErr } = await supabase.from('iam_groups').select('id').limit(1);
+    latencyMs = Date.now() - start;
     healthy = !pingErr;
 
-    // Table stats via pg_stat_user_tables (raw SQL via rpc if available)
-    // Fallback: list known public tables with record counts
-    const knownTables = [
-      'iam_roles', 'iam_groups', 'iam_user_group_memberships',
-      'ai_performance_metrics', 'web_analytics', 'behavior_logs',
-      'web_vitals', 'user_page_settings', 'module_model_assignments',
-    ];
+    connectionCount = await getConnectionCount(supabase);
 
     const tableResults = await Promise.allSettled(
-      knownTables.map(async (t) => {
-        const { count } = await supabase.from(t).select('*', { count: 'exact', head: true });
-        return { tablename: t, count: count ?? 0 };
-      })
+      KNOWN_TABLES.map(async (tableName) => {
+        const [{ count }, lastUpdatedAt] = await Promise.all([
+          supabase.from(tableName).select('*', { count: 'exact', head: true }),
+          getTableLastUpdatedAt(supabase, tableName),
+        ]);
+
+        return {
+          schemaname: 'public',
+          tablename: tableName,
+          n_live_tup: count ?? 0,
+          n_dead_tup: 0,
+          last_updated_at: lastUpdatedAt,
+        } as TableStat;
+      }),
     );
 
     tablestats = tableResults
-      .filter((r): r is PromiseFulfilledResult<{ tablename: string; count: number }> => r.status === 'fulfilled')
-      .map(r => ({
-        schemaname: 'public',
-        tablename: r.value.tablename,
-        n_live_tup: r.value.count,
-        n_dead_tup: 0,
-        last_autovacuum: null,
-      }));
+      .filter((result): result is PromiseFulfilledResult<TableStat> => result.status === 'fulfilled')
+      .map((result) => result.value);
 
-    // User count from auth.users
     const { count: uCount } = await supabase
       .from('iam_user_group_memberships')
       .select('user_id', { count: 'exact', head: true });
     userCount = uCount ?? 0;
 
-    // RLS policies: use pg_policies view if accessible
     const { data: policies } = await supabase.rpc('get_rls_policies').maybeSingle();
-    if (policies) {
-      rlsPolicies = policies as RLSPolicy[];
-    }
-  } catch (err) {
-    console.error('Error fetching DB stats:', err);
+    if (policies) rlsPolicies = policies as RLSPolicy[];
+
+    migrationHistory = await getMigrationHistory(supabase);
+  } catch (error) {
+    console.error('Error fetching Supabase dashboard stats:', error);
   }
 
-  return { healthy, tablestats, rlsPolicies, userCount };
+  return {
+    healthy,
+    latencyMs,
+    connectionCount,
+    tablestats,
+    rlsPolicies,
+    userCount,
+    migrationHistory,
+  };
 }
 
 export default async function SupabasePage() {
-  const { healthy, tablestats, rlsPolicies, userCount } = await getDatabaseStats();
+  const {
+    healthy,
+    latencyMs,
+    connectionCount,
+    tablestats,
+    rlsPolicies,
+    userCount,
+    migrationHistory,
+  } = await getDatabaseStats();
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
   const projectRef = supabaseUrl.match(/https:\/\/([^.]+)\.supabase\.co/)?.[1] ?? '';
@@ -95,9 +243,12 @@ export default async function SupabasePage() {
     >
       <SupabaseDashboardClient
         healthy={healthy}
+        latencyMs={latencyMs}
+        connectionCount={connectionCount}
         tablestats={tablestats}
         rlsPolicies={rlsPolicies}
         userCount={userCount}
+        migrationHistory={migrationHistory}
         projectRef={projectRef}
         supabaseUrl={supabaseUrl}
       />

--- a/apps/superadmin/app/superadmin/dashboard/supabase/page.tsx
+++ b/apps/superadmin/app/superadmin/dashboard/supabase/page.tsx
@@ -95,9 +95,11 @@ async function getMigrationHistory(
 
   const migrationSchemaClient =
     typeof (supabase as { schema?: unknown }).schema === 'function'
-      ? (supabase as { schema: (schemaName: string) => ReturnType<typeof createAdminClient> }).schema(
-          'supabase_migrations',
-        )
+      ? (
+          supabase as unknown as {
+            schema: (schemaName: string) => ReturnType<typeof createAdminClient>;
+          }
+        ).schema('supabase_migrations')
       : supabase;
 
   const { data: appliedRows } = await migrationSchemaClient
@@ -139,7 +141,9 @@ async function getConnectionCount(
     if (typeof (supabase as { schema?: unknown }).schema !== 'function') return null;
 
     const pgCatalogClient = (
-      supabase as { schema: (schemaName: string) => ReturnType<typeof createAdminClient> }
+      supabase as unknown as {
+        schema: (schemaName: string) => ReturnType<typeof createAdminClient>;
+      }
     ).schema('pg_catalog');
 
     const { count, error } = await pgCatalogClient


### PR DESCRIPTION
## Summary

- 擴充 `apps/superadmin/app/superadmin/dashboard/supabase` 功能：
  - Table update timestamps
  - SELECT-only SQL runner（`app/api/supabase/sql/route.ts` 新增）
  - Migration history 檢視
  - DB health metrics
  - 手動備份觸發與下載 UI
- 3 檔變動、+624/-64 行
- 從 reflog 救回的 commit `85667db`

## 背景

原分支 `feature/paperclip-row-006`（Paperclip Agent 2026-04-16）從未合入 main。Merge-base 為 `24626c50`，之後 main 有 14 個 commits 含 lint/typecheck/Next 16 相關變更。git 層面無衝突，但**語意相容需驗證**。

## ⚠️ 合入前請驗證

- [ ] `npm run build --workspace superadmin` 通過
- [ ] `npm run typecheck --workspace superadmin` 通過
- [ ] `tools/testing/lint-adapter-model-ids.sh` 不受影響
- [ ] 手動煙測：
  - [ ] SQL runner 只接受 SELECT（其他語句應拒絕）
  - [ ] Migration history 頁面載入
  - [ ] 手動備份 API 可下載檔案
- [ ] 確認沒引入 `any`（pre-commit `check-staged-no-any.js` 會抓）

## Test plan

- [ ] 建議在本地 rebase main 後跑完整 CI 再 merge
- [ ] 若衝突太大可考慮重新讓 Paperclip Agent 基於最新 main 重做

🤖 Generated with [Claude Code](https://claude.com/claude-code)