### PR TITLE
fix(superadmin): guard /api/supabase/sql behind superadmin auth

### DIFF
--- a/apps/superadmin/app/api/supabase/sql/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/supabase/sql/__tests__/route.test.ts
@@ -1,0 +1,162 @@
+// Regression tests for Issue #31 — /api/supabase/sql must require a
+// super_admin session before running any SQL via the admin (service_role)
+// client. Historically this endpoint was reachable without a cookie because
+// middleware.ts's matcher does not cover /api/*.
+
+import { NextRequest } from 'next/server';
+
+// --- Mocks -----------------------------------------------------------------
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  message?: string;
+  userId?: string;
+}
+
+const authState: AuthState = { ok: true, userId: 'admin-1' };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return {
+        ok: true,
+        userId: authState.userId ?? 'admin-1',
+        source: 'session' as const,
+        viaSession: true,
+      };
+    }
+    return {
+      ok: false,
+      status: authState.status ?? 401,
+      message: authState.message ?? 'Unauthorized',
+    };
+  }),
+}));
+
+interface QueryResult {
+  data: unknown[] | null;
+  error: null | { message: string };
+}
+const queryResult: QueryResult = { data: [], error: null };
+
+const fromSpy = jest.fn();
+const schemaSpy = jest.fn();
+const selectSpy = jest.fn();
+const limitSpy = jest.fn();
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => {
+    // Chainable stub: admin.from(t).select(c).limit(n)
+    // or admin.schema(s).from(t).select(c).limit(n)
+    const limit = (n: number) => {
+      limitSpy(n);
+      return Promise.resolve({ data: queryResult.data, error: queryResult.error });
+    };
+    const select = (cols: string) => {
+      selectSpy(cols);
+      return { limit };
+    };
+    const from = (table: string) => {
+      fromSpy(table);
+      return { select };
+    };
+    const schema = (name: string) => {
+      schemaSpy(name);
+      return { from };
+    };
+    return { from, schema };
+  },
+}));
+
+// --- Import after mocks ----------------------------------------------------
+
+import { POST } from '../route';
+
+// --- Helpers ---------------------------------------------------------------
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/supabase/sql', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  authState.message = undefined;
+  authState.userId = 'admin-1';
+  queryResult.data = [];
+  queryResult.error = null;
+});
+
+// ---------------------------------------------------------------------------
+
+describe('POST /api/supabase/sql', () => {
+  it('returns 401 when requireSuperadmin responds ok:false status:401', async () => {
+    authState.ok = false;
+    authState.status = 401;
+
+    const res = await POST(postReq({ query: 'SELECT id FROM platform_settings LIMIT 1' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns 403 when requireSuperadmin responds ok:false status:403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+
+    const res = await POST(postReq({ query: 'SELECT id FROM platform_settings LIMIT 1' }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns 200 with rows for a valid SELECT by super_admin', async () => {
+    queryResult.data = [{ id: '11111111-1111-1111-1111-111111111111' }];
+
+    const res = await POST(postReq({ query: 'SELECT id FROM platform_settings LIMIT 1' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rowCount).toBe(1);
+    expect(body.rows).toEqual([{ id: '11111111-1111-1111-1111-111111111111' }]);
+    expect(body.table).toBe('public.platform_settings');
+    // Admin client must be invoked only after auth passes.
+    expect(fromSpy).toHaveBeenCalledWith('platform_settings');
+    expect(selectSpy).toHaveBeenCalled();
+    expect(limitSpy).toHaveBeenCalled();
+  });
+
+  it('returns 400 when body contains INSERT (forbidden SQL kept after auth passes)', async () => {
+    const res = await POST(
+      postReq({ query: "INSERT INTO platform_settings (id) VALUES ('x')" }),
+    );
+    expect(res.status).toBe(400);
+    // Forbidden SQL must never reach the admin client.
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when body is empty', async () => {
+    const res = await POST(postReq({}));
+    expect(res.status).toBe(400);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not query the database when auth fails (regression guard for Issue #31)', async () => {
+    authState.ok = false;
+    authState.status = 401;
+
+    const res = await POST(postReq({ query: 'SELECT id FROM platform_settings LIMIT 1' }));
+    expect(res.status).toBe(401);
+    // The admin client must never be reached when auth fails — this is the
+    // actual CVE regression: previously the handler queried the DB first.
+    expect(fromSpy).not.toHaveBeenCalled();
+    expect(schemaSpy).not.toHaveBeenCalled();
+    expect(selectSpy).not.toHaveBeenCalled();
+    expect(limitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/superadmin/app/api/supabase/sql/route.ts
+++ b/apps/superadmin/app/api/supabase/sql/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 const MAX_LIMIT = 200;
 const FORBIDDEN_SQL = /(insert|update|delete|drop|alter|create|grant|revoke|truncate|call|execute|copy)\b/i;
@@ -44,6 +45,19 @@ function parseSelectQuery(raw: string): ParsedSelect | null {
 }
 
 export async function POST(req: NextRequest) {
+  // Issue #31: gate this endpoint behind a super_admin Supabase session.
+  // The route uses the admin (service_role) client below, which bypasses RLS,
+  // and middleware.ts's matcher does not cover /api/*, so without this check
+  // any unauthenticated caller could read arbitrary tables.
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/supabase/sql',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.message }, { status: auth.status });
+  }
+
   try {
     const body = (await req.json().catch(() => ({}))) as { query?: string };
     const query = body.query ?? '';


### PR DESCRIPTION
Closes #31

## Summary
- `/api/supabase/sql` POST handler now short-circuits with `requireSuperadmin({ allowHeaderFallback: false })` **before** parsing the body or touching the admin client.
- Fixes the information-disclosure regression: middleware matcher excludes `/api/*`, and this route uses `createAdminClient` (service_role, bypasses RLS), so any unauthenticated caller could read arbitrary tables via the SELECT whitelist.
- New Jest suite `app/api/supabase/sql/__tests__/route.test.ts` — 6 cases: 401 / 403 / 200 / 400 (INSERT blocked) / 400 (empty body) / regression guard asserting admin client is never reached when auth fails.

## Why `allowHeaderFallback: false`
This endpoint has never supported the legacy `x-user-id` header, so we opt out of that fallback path — session cookies only. Consistent with `docs/ai-prompt-safety-guide.md` §6.1 direction for superadmin LLM / data endpoints.

## Verification
- `npx jest app/api/supabase/sql/__tests__/route.test.ts` → **6 passed**
- `npx tsc --noEmit -p apps/superadmin/tsconfig.json` → **0 errors** (after clearing stale `.next/dev/types/`)
- `npm run build --workspace superadmin` → **Compiled successfully in 24.4s**, `/api/supabase/sql` present in routes manifest
- Smoke test (against `npm run start --workspace superadmin`):
  ```
  $ curl -s -o - -w "\nHTTP %{http_code}\n" -X POST http://localhost:3001/api/supabase/sql \
      -H 'Content-Type: application/json' \
      -d '{"query":"SELECT id FROM platform_settings LIMIT 1"}'
  {"error":"Unauthorized: missing session or header identity"}
  HTTP 401
  ```
  Previously returned HTTP 200 with real rows.

## Out of scope (follow-ups)
- Audit remaining `/api/*` routes not covered by `middleware.ts` matcher (people-db, paperclip, webhooks) — belongs in a separate tracking issue.
- Tighten `SUPPORTED_SELECT` regex: currently accepts `"` and could be narrowed to bare column lists.

## Test plan
- [ ] CI Jest suite green (includes new 6 cases)
- [ ] CI typecheck green
- [ ] CI lint green
- [ ] Manually sign in as super_admin and confirm the Supabase dashboard SQL runner still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)