### PR TITLE
fix(superadmin): guard 6 P0 admin-client routes behind superadmin auth (#34 PR A)

### DIFF
--- a/apps/superadmin/app/api/backup/cloud-settings/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/backup/cloud-settings/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+// Regression tests for Issue #34 — /api/backup/cloud-settings must require a
+// super_admin session on both GET (returns masked credential state) and POST
+// (writes GDrive service-account JSON / S3 secret key).
+
+import { NextRequest } from 'next/server';
+
+// --- Auth mock -------------------------------------------------------------
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+}
+const authState: AuthState = { ok: true };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, userId: 'admin-1', source: 'session' as const, viaSession: true };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+// --- Admin client mock -----------------------------------------------------
+
+const fromSpy = jest.fn();
+const upsertSpy = jest.fn();
+const loadedValue: { gdrive?: Record<string, unknown>; s3?: Record<string, unknown> } = {};
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => {
+    const single = () => {
+      const key = fromSpy.mock.calls.length > 0 ? null : null;
+      void key;
+      return Promise.resolve({ data: { value: {} }, error: null });
+    };
+    const eq = () => ({ single });
+    const select = () => ({ eq });
+    const upsert = (...args: unknown[]) => {
+      upsertSpy(...args);
+      return Promise.resolve({ error: null });
+    };
+    const from = (table: string) => {
+      fromSpy(table);
+      return { select, upsert };
+    };
+    return { from };
+  },
+}));
+
+// --- Import after mocks ----------------------------------------------------
+
+import { GET, POST } from '../route';
+
+function getReq(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/backup/cloud-settings', { method: 'GET' });
+}
+function postReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/backup/cloud-settings', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  loadedValue.gdrive = undefined;
+  loadedValue.s3 = undefined;
+});
+
+describe('/api/backup/cloud-settings', () => {
+  it('GET returns 401 when auth fails with 401', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('GET returns 403 when auth fails with 403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await GET(getReq());
+    expect(res.status).toBe(403);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('GET returns 200 with masked config for super_admin', async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.gdrive).toHaveProperty('configured');
+    expect(body.s3).toHaveProperty('configured');
+    // Masked: never return raw secrets
+    expect(body.gdrive).not.toHaveProperty('service_account_json');
+    expect(body.s3).not.toHaveProperty('secret_access_key');
+    expect(fromSpy).toHaveBeenCalledWith('system_settings');
+  });
+
+  it('POST returns 401 when auth fails (regression guard)', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(postReq({ gdrive: { enabled: true } }));
+    expect(res.status).toBe(401);
+    // The admin client must never be reached when auth fails — previously any
+    // caller could overwrite GDrive service-account JSON / S3 secret key.
+    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('POST returns 200 and upserts credentials for super_admin', async () => {
+    const res = await POST(postReq({ gdrive: { enabled: true, folder_id: 'xyz' } }));
+    expect(res.status).toBe(200);
+    expect(upsertSpy).toHaveBeenCalled();
+  });
+
+  it('POST with empty body is a no-op 200', async () => {
+    const res = await POST(postReq({}));
+    expect(res.status).toBe(200);
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/superadmin/app/api/backup/cloud-settings/route.ts
+++ b/apps/superadmin/app/api/backup/cloud-settings/route.ts
@@ -4,6 +4,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 export interface GDriveConfig {
   enabled: boolean;
@@ -48,7 +49,16 @@ async function loadConfig<T>(key: string, defaults: T): Promise<T> {
   return data?.value ? { ...defaults, ...(data.value as Partial<T>) } : defaults;
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/backup/cloud-settings',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   const [gdrive, s3] = await Promise.all([
     loadConfig<GDriveConfig>(GDRIVE_KEY, defaultGDrive),
     loadConfig<S3Config>(S3_KEY, defaultS3),
@@ -74,6 +84,15 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/backup/cloud-settings',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   const body = await req.json() as {
     gdrive?: Partial<GDriveConfig>;
     s3?: Partial<S3Config>;

--- a/apps/superadmin/app/api/backup/health/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/backup/health/__tests__/route.test.ts
@@ -1,0 +1,119 @@
+// Regression tests for Issue #34 — /api/backup/health must require a
+// super_admin session before probing storage bucket counts via the admin
+// (service_role) client.
+
+import { NextRequest } from 'next/server';
+
+// --- Auth mock -------------------------------------------------------------
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+}
+const authState: AuthState = { ok: true };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, userId: 'admin-1', source: 'session' as const, viaSession: true };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+// --- fs mock ---------------------------------------------------------------
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => false),
+  readFileSync: jest.fn(() => '{}'),
+  readdirSync: jest.fn(() => []),
+}));
+
+// --- Admin client mock -----------------------------------------------------
+
+const fromSpy = jest.fn();
+const schemaSpy = jest.fn();
+const selectSpy = jest.fn();
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => {
+    const eq = () => Promise.resolve({ count: 1, error: null });
+    const select = (...args: unknown[]) => {
+      selectSpy(...args);
+      // Terminal for simple .select(...) with no .eq(...): return a thenable
+      // that resolves to the count payload. Also expose .eq() for chains
+      // that filter by bucket_id / is_active.
+      const terminal = Promise.resolve({ count: 1, error: null });
+      return {
+        eq,
+        then: terminal.then.bind(terminal),
+      };
+    };
+    const from = (table: string) => {
+      fromSpy(table);
+      return { select };
+    };
+    const schema = (name: string) => {
+      schemaSpy(name);
+      return { from };
+    };
+    return { from, schema };
+  },
+}));
+
+// --- Import after mocks ----------------------------------------------------
+
+import { GET } from '../route';
+
+function getReq(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/backup/health', { method: 'GET' });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+});
+
+describe('GET /api/backup/health', () => {
+  it('returns 401 when auth fails with 401', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+    expect(schemaSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when auth fails with 403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await GET(getReq());
+    expect(res.status).toBe(403);
+    expect(fromSpy).not.toHaveBeenCalled();
+    expect(schemaSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with health snapshot for super_admin', async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('healthy');
+    expect(body).toHaveProperty('property_photos');
+    expect(body).toHaveProperty('property_documents');
+    expect(body).toHaveProperty('backup_count');
+    expect(fromSpy).toHaveBeenCalledWith('property_photos');
+    expect(fromSpy).toHaveBeenCalledWith('property_documents');
+    expect(schemaSpy).toHaveBeenCalledWith('storage');
+  });
+
+  it('does not probe storage when auth fails (regression guard)', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+    expect(schemaSpy).not.toHaveBeenCalled();
+    expect(selectSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/superadmin/app/api/backup/health/route.ts
+++ b/apps/superadmin/app/api/backup/health/route.ts
@@ -1,14 +1,24 @@
 // filepath: apps/superadmin/app/api/backup/health/route.ts
 // GET /api/backup/health → storage integrity check
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 const BACKUP_DIR = path.resolve(process.cwd(), 'backups');
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/backup/health',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   const adminClient = createAdminClient();
 
   const [

--- a/apps/superadmin/app/api/backup/restore/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/backup/restore/__tests__/route.test.ts
@@ -1,0 +1,141 @@
+// Regression tests for Issue #34 — /api/backup/restore must require a
+// super_admin session before upserting rows via the admin (service_role)
+// client. Without the guard, any unauthenticated POST could trigger a full
+// data restore from a file whose id matches the naming pattern.
+
+import { NextRequest } from 'next/server';
+
+// --- Auth mock -------------------------------------------------------------
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  message?: string;
+}
+const authState: AuthState = { ok: true };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, userId: 'admin-1', source: 'session' as const, viaSession: true };
+    }
+    return {
+      ok: false,
+      status: authState.status ?? 401,
+      message: authState.message ?? 'Unauthorized',
+    };
+  }),
+}));
+
+// --- fs mock ---------------------------------------------------------------
+
+const backupPayload = {
+  version: '2.0',
+  data: {
+    property_photos: [{ id: 'p1' }],
+  },
+};
+const fsState = { exists: true };
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => fsState.exists),
+  readFileSync: jest.fn(() => JSON.stringify(backupPayload)),
+  readdirSync: jest.fn(() => []),
+}));
+
+// --- Admin client mock -----------------------------------------------------
+
+const upsertSpy = jest.fn();
+const fromSpy = jest.fn();
+const schemaSpy = jest.fn();
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => {
+    const upsert = (...args: unknown[]) => {
+      upsertSpy(...args);
+      return Promise.resolve({ error: null });
+    };
+    const from = (table: string) => {
+      fromSpy(table);
+      return { upsert };
+    };
+    const schema = (name: string) => {
+      schemaSpy(name);
+      return { from };
+    };
+    return { from, schema };
+  },
+}));
+
+// --- Import after mocks ----------------------------------------------------
+
+import { POST } from '../route';
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/backup/restore', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  fsState.exists = true;
+});
+
+describe('POST /api/backup/restore', () => {
+  it('returns 401 when requireSuperadmin responds ok:false status:401', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(postReq({ id: 'backup_20260419_120000' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns 403 when requireSuperadmin responds ok:false status:403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await POST(postReq({ id: 'backup_20260419_120000' }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns 200 and upserts rows for a valid backup id by super_admin', async () => {
+    const res = await POST(postReq({ id: 'backup_20260419_120000' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('restored');
+    expect(fromSpy).toHaveBeenCalledWith('property_photos');
+    expect(upsertSpy).toHaveBeenCalled();
+  });
+
+  it('returns 400 when backup id does not match pattern', async () => {
+    const res = await POST(postReq({ id: 'not-a-valid-id' }));
+    expect(res.status).toBe(400);
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when backup file is missing', async () => {
+    fsState.exists = false;
+    const res = await POST(postReq({ id: 'backup_20260419_120000' }));
+    expect(res.status).toBe(404);
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not restore when auth fails (regression guard for Issue #34)', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(postReq({ id: 'backup_20260419_120000' }));
+    expect(res.status).toBe(401);
+    // The admin client must never be reached when auth fails — previously
+    // any caller could trigger a full database restore.
+    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(fromSpy).not.toHaveBeenCalled();
+    expect(schemaSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/superadmin/app/api/backup/restore/route.ts
+++ b/apps/superadmin/app/api/backup/restore/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 const BACKUP_DIR = path.resolve(process.cwd(), 'backups');
 
@@ -17,6 +18,15 @@ interface RestoreResult {
 }
 
 export async function POST(req: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/backup/restore',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   const { id } = (await req.json()) as { id: string };
   if (!/^backup_\d{8}_\d{6}$/.test(id)) {
     return NextResponse.json({ error: 'Invalid backup id' }, { status: 400 });

--- a/apps/superadmin/app/api/backup/run-logs/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/backup/run-logs/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+// Regression tests for Issue #34 — /api/backup/run-logs must require a
+// super_admin session before exposing the backup execution audit trail.
+
+import { NextRequest } from 'next/server';
+
+// --- Auth mock -------------------------------------------------------------
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+}
+const authState: AuthState = { ok: true };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, userId: 'admin-1', source: 'session' as const, viaSession: true };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+// --- Admin client mock -----------------------------------------------------
+
+const fromSpy = jest.fn();
+const selectSpy = jest.fn();
+const queryResult: { data: unknown[] | null; error: null | { message: string } } = {
+  data: [{ id: '1', trigger: 'manual' }],
+  error: null,
+};
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => {
+    const limit = () => Promise.resolve(queryResult);
+    const order = () => ({ limit });
+    const select = (...args: unknown[]) => {
+      selectSpy(...args);
+      return { order };
+    };
+    const from = (table: string) => {
+      fromSpy(table);
+      return { select };
+    };
+    return { from };
+  },
+}));
+
+// --- Import after mocks ----------------------------------------------------
+
+import { GET } from '../route';
+
+function getReq(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/backup/run-logs', { method: 'GET' });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  queryResult.data = [{ id: '1', trigger: 'manual' }];
+  queryResult.error = null;
+});
+
+describe('GET /api/backup/run-logs', () => {
+  it('returns 401 when auth fails with 401', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when auth fails with 403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await GET(getReq());
+    expect(res.status).toBe(403);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with logs for super_admin', async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.logs)).toBe(true);
+    expect(fromSpy).toHaveBeenCalledWith('backup_run_logs');
+  });
+
+  it('returns 500 when the underlying query errors', async () => {
+    queryResult.data = null;
+    queryResult.error = { message: 'db down' };
+    const res = await GET(getReq());
+    expect(res.status).toBe(500);
+  });
+
+  it('does not query the database when auth fails (regression guard)', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+    expect(selectSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/superadmin/app/api/backup/run-logs/route.ts
+++ b/apps/superadmin/app/api/backup/run-logs/route.ts
@@ -1,12 +1,22 @@
 // GET /api/backup/run-logs — recent backup execution audit rows (superadmin)
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/backup/run-logs',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   const admin = createAdminClient();
   const { data, error } = await admin
     .from('backup_run_logs')

--- a/apps/superadmin/app/api/backup/settings/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/backup/settings/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+// Regression tests for Issue #34 — /api/backup/settings must require a
+// super_admin session on both GET and POST before using the admin client.
+
+import { NextRequest } from 'next/server';
+
+// --- Auth mock -------------------------------------------------------------
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  message?: string;
+}
+const authState: AuthState = { ok: true };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, userId: 'admin-1', source: 'session' as const, viaSession: true };
+    }
+    return {
+      ok: false,
+      status: authState.status ?? 401,
+      message: authState.message ?? 'Unauthorized',
+    };
+  }),
+}));
+
+// --- Admin client mock -----------------------------------------------------
+
+const upsertSpy = jest.fn();
+const fromSpy = jest.fn();
+const selectSpy = jest.fn();
+const upsertError: { value: null | { message: string } } = { value: null };
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => {
+    const single = () => Promise.resolve({ data: { value: {} }, error: null });
+    const eq = () => ({ single });
+    const select = () => {
+      selectSpy();
+      return { eq };
+    };
+    const upsert = (...args: unknown[]) => {
+      upsertSpy(...args);
+      return Promise.resolve({ error: upsertError.value });
+    };
+    const from = (table: string) => {
+      fromSpy(table);
+      return { select, upsert };
+    };
+    return { from };
+  },
+}));
+
+// --- Import after mocks ----------------------------------------------------
+
+import { GET, POST } from '../route';
+
+function getReq(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/backup/settings', { method: 'GET' });
+}
+function postReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/backup/settings', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  upsertError.value = null;
+});
+
+describe('/api/backup/settings', () => {
+  it('GET returns 401 when auth fails with 401', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('GET returns 403 when auth fails with 403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await GET(getReq());
+    expect(res.status).toBe(403);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('GET returns 200 with normalized settings for super_admin', async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    expect(fromSpy).toHaveBeenCalledWith('system_settings');
+    expect(selectSpy).toHaveBeenCalled();
+  });
+
+  it('POST returns 401 when auth fails (regression guard for Issue #34)', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(postReq({ local_device_enabled: true }));
+    expect(res.status).toBe(401);
+    // The admin client must never be reached when auth fails.
+    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('POST returns 200 and upserts for super_admin', async () => {
+    const res = await POST(postReq({ local_device_enabled: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(upsertSpy).toHaveBeenCalled();
+  });
+
+  it('POST returns 500 when upsert fails', async () => {
+    upsertError.value = { message: 'db down' };
+    const res = await POST(postReq({ local_device_enabled: true }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+});

--- a/apps/superadmin/app/api/backup/settings/route.ts
+++ b/apps/superadmin/app/api/backup/settings/route.ts
@@ -4,6 +4,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import {
   BACKUP_SETTINGS_KEY,
   backupSettingsDefaults,
@@ -11,7 +12,16 @@ import {
   type BackupSettings,
 } from '@/lib/backup/settings';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/backup/settings',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   const adminClient = createAdminClient();
   const { data } = await adminClient
     .from('system_settings')
@@ -22,6 +32,15 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/backup/settings',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   const body = (await req.json()) as Partial<BackupSettings>;
   const adminClient = createAdminClient();
 

--- a/apps/superadmin/app/api/iam/audit/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/iam/audit/__tests__/route.test.ts
@@ -1,0 +1,134 @@
+// Regression tests for Issue #34 — /api/iam/audit must require a super_admin
+// session before invoking admin.auth.admin.listUsers() or reading rbac_audit_logs.
+// Without the guard, any unauthenticated caller can enumerate every registered
+// email, IAM group, role, and audit trail in a single request.
+
+import { NextRequest } from 'next/server';
+
+// --- Auth mock -------------------------------------------------------------
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  message?: string;
+}
+const authState: AuthState = { ok: true };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, userId: 'admin-1', source: 'session' as const, viaSession: true };
+    }
+    return {
+      ok: false,
+      status: authState.status ?? 401,
+      message: authState.message ?? 'Unauthorized',
+    };
+  }),
+}));
+
+// --- Admin client mock -----------------------------------------------------
+
+const listUsersSpy = jest.fn();
+const fromSpy = jest.fn();
+const rpcSpy = jest.fn();
+
+interface TableState {
+  data: unknown;
+  error: null | { message: string };
+}
+const tableState: Record<string, TableState> = {
+  iam_groups: { data: [], error: null },
+  iam_roles: { data: [], error: null },
+  rbac_audit_logs: { data: [], error: null },
+};
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    auth: {
+      admin: {
+        listUsers: (...args: unknown[]) => {
+          listUsersSpy(...args);
+          return Promise.resolve({ data: { users: [] }, error: null });
+        },
+      },
+    },
+    from: (table: string) => {
+      fromSpy(table);
+      const state = tableState[table] ?? { data: [], error: null };
+      const terminal = Promise.resolve(state);
+      const chain = {
+        select: () => chain,
+        order: () => chain,
+        limit: () => terminal,
+        then: terminal.then.bind(terminal),
+      };
+      return chain;
+    },
+    rpc: (name: string) => {
+      rpcSpy(name);
+      return { single: () => Promise.resolve({ data: 0, error: null }) };
+    },
+  }),
+}));
+
+// --- Import after mocks ----------------------------------------------------
+
+import { GET } from '../route';
+
+function getReq(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/iam/audit', { method: 'GET' });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  authState.message = undefined;
+});
+
+describe('GET /api/iam/audit', () => {
+  it('returns 401 when requireSuperadmin responds ok:false status:401', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns 403 when requireSuperadmin responds ok:false status:403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await GET(getReq());
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns 200 with snapshot/stats/logs for a valid super_admin', async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('snapshot');
+    expect(body).toHaveProperty('stats');
+    expect(body).toHaveProperty('logs');
+    expect(listUsersSpy).toHaveBeenCalled();
+    expect(fromSpy).toHaveBeenCalledWith('iam_groups');
+    expect(fromSpy).toHaveBeenCalledWith('iam_roles');
+    expect(fromSpy).toHaveBeenCalledWith('rbac_audit_logs');
+  });
+
+  it('does not enumerate users when auth fails (regression guard for Issue #34)', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    // The admin client must never be reached when auth fails — this is the
+    // actual CVE regression: previously the handler listed every auth.users
+    // row for any unauthenticated caller.
+    expect(listUsersSpy).not.toHaveBeenCalled();
+    expect(fromSpy).not.toHaveBeenCalled();
+    expect(rpcSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/superadmin/app/api/iam/audit/route.ts
+++ b/apps/superadmin/app/api/iam/audit/route.ts
@@ -1,7 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/iam/audit',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   try {
     const admin = createAdminClient();
 


### PR DESCRIPTION
Follow-up to #31 (PR #32). Closes the first batch identified in [#34 Phase 1 audit](https://github.com/jason660519/Owner-Property-Management-AI-SPA/issues/34#issuecomment-4274752835).

## 背景

`apps/superadmin/middleware.ts` matcher `['/docs', '/superadmin/:path*']` **不涵蓋 `/api/*`**。Phase 1 audit 於 #34 發現 **38 個 route** 使用 `createAdminClient`（service_role、繞 RLS）但沒有任何 guard。本 PR 處理最高風險的 **P0 批次**：

- **2 支完全無 auth**：`/api/iam/audit`、`/api/backup/restore`
- **5 支 backup 相關**：`/api/backup/{settings,cloud-settings,run-logs,health}`

## 為什麼重要（比 #31 還嚴重）

| Route | 未授權可觸發 |
| :-- | :-- |
| `/api/iam/audit` GET | 列舉全部 `auth.users` email、IAM groups/roles、RBAC audit logs |
| `/api/backup/restore` POST | 任何符合命名 pattern 的 backup id 均可觸發完整資料還原 |
| `/api/backup/cloud-settings` POST | 可覆寫 GDrive service-account JSON / S3 secret key |
| `/api/backup/settings` POST | 可改備份目的地路徑、排程、保留數 |
| `/api/backup/run-logs` GET | 曝光備份執行 audit trail |
| `/api/backup/health` GET | 透過 service_role 查 `storage.objects` bucket count |

## 實作

每支 route 最前面加 `requireSuperadmin({ request, allowHeaderFallback: false, routeLabel })`，auth fail 回 401/403 JSON，對齊 #31 的 pattern。**不接受 `x-user-id` header fallback**（依 #34 決策 2：legacy header 一律棄用）。

對於原本沒有 `request` 參數的 GET handler，補上 `request: NextRequest` signature。

## 測試（6 檔、31 cases）

每個 guarded handler 的 `__tests__/route.test.ts` 至少涵蓋：
1. **401** — auth returns `{ok:false, status:401}`
2. **403** — auth returns `{ok:false, status:403}`
3. **200** — happy path，admin client 被呼叫
4. **regression guard** — auth fail 時 admin client **不被呼叫**

有天然 branch 的 route 額外補 edge case：
- `backup/restore` → 400 invalid id + 404 missing file（共 6 case）
- `backup/settings` POST → 500 upsert error（共 6 case）
- `backup/cloud-settings` POST → empty body no-op（共 6 case）
- `backup/run-logs` → 500 query error（共 5 case）

## 驗證

| 項目 | 結果 |
| :-- | :-- |
| jest（本 PR 6 suites） | **31 / 31 pass** |
| jest（全 superadmin workspace） | 1426 pass / 2 skipped；12 failures **全為 pre-existing**（stashed 本 PR 後在乾淨 main 重現：`DashboardHeader.theme-toggle` / `elasticsearch/route` / `ModelEvaluator.provider-filter`）— 不在本 PR 範圍 |
| \`tsc --noEmit\` | 0 errors |
| \`validate-test-manifest.sh\` | pass（21 entries，未變） |
| \`next build\` | Compiled successfully in 26.9s |

## 不在本 PR（追蹤於 #34）

| PR | 範圍 |
| :-- | :-- |
| **B** | 14 `ai-settings/*` + `ai-billing/anthropic` 從 legacy `x-user-id` 全改 session-based |
| **C** | 7 `paperclip/*` 路由 |
| **D** | `dev-tasks`、`documents`、`transcript-parse`、`system-health`、`property-description/prompt-config` |
| **E** | 統一 helper：deprecate `es-gateway.ts::requireSuperAdmin`（大寫 A，admin-client + `x-user-id`）→ `lib/auth/require-superadmin.ts`（小寫 admin，session + `get_user_roles` RPC） |
| **F** | 擴 `middleware.ts` matcher 至 `/api/:path*`（排除 webhooks 和 auth callbacks），API 模式回 JSON 401 而非 redirect |

## Test plan

- [x] 401 返回且 admin client 未觸發
- [x] 403 返回
- [x] 200 happy path 各 route 查詢路徑正確
- [x] regression guard：auth fail 時 admin client 完全未被呼叫
- [x] 400/404/500 天然 branch 有覆蓋
- [x] tsc / build / validate-test-manifest 全綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)