### PR TITLE
fix(superadmin): guard 7 paperclip routes + INTERNAL_API_KEY dual-track auth (#34 PR C)

### DIFF
--- a/.claude/skills/dispatch-agents/SKILL.md
+++ b/.claude/skills/dispatch-agents/SKILL.md
@@ -166,8 +166,11 @@ autoplan → ship。
 
 #### ✅ 正確做法：透過 Superadmin API
 
+**Issue #34 PR C 起**：superadmin `/api/paperclip/*` 端點需要認證。shell caller（包含本 skill）必須帶 `Authorization: Bearer $INTERNAL_API_KEY`。用 `tools/paperclip/auth-header.sh` 產生 header（會從 `apps/superadmin/.env.local` 讀 `INTERNAL_API_KEY`）。
+
 ```bash
 curl -s -X POST "http://localhost:3001/api/paperclip/issues" \
+  -H "$(bash tools/paperclip/auth-header.sh)" \
   -H "Content-Type: application/json" \
   -d '{
     "title": "[Row 031] 房東的客戶 Grid模式",
@@ -325,10 +328,14 @@ curl -X PATCH -H "$AUTH" -H "Content-Type: application/json" \
 ```bash
 # 取消
 curl -s -X POST "http://localhost:3001/api/paperclip/issues/{issueId}/update" \
+  -H "$(bash tools/paperclip/auth-header.sh)" \
   -H "Content-Type: application/json" -d '{"status":"cancelled"}'
 
-# 重新建立（透過 superadmin）
-curl -s -X POST "http://localhost:3001/api/paperclip/issues" ...
+# 重新建立（透過 superadmin）— 每一支 localhost:3001/api/paperclip/* 呼叫都要加
+# -H "$(bash tools/paperclip/auth-header.sh)"
+curl -s -X POST "http://localhost:3001/api/paperclip/issues" \
+  -H "$(bash tools/paperclip/auth-header.sh)" \
+  -H "Content-Type: application/json" -d '{ ... }'
 ```
 
 ### Paperclip 容器 crash（exit code 137 = OOM）
@@ -348,13 +355,15 @@ docker compose -f docker/paperclip/docker-compose.paperclip.yml \
 
 ```bash
 curl -s -X POST "http://localhost:3001/api/paperclip/worktrees/cleanup" \
+  -H "$(bash tools/paperclip/auth-header.sh)" \
   -H "Content-Type: application/json"
 ```
 
 ### 查詢現有 worktrees
 
 ```bash
-curl -s "http://localhost:3001/api/paperclip/worktrees"
+curl -s "http://localhost:3001/api/paperclip/worktrees" \
+  -H "$(bash tools/paperclip/auth-header.sh)"
 ```
 
 ---
@@ -365,10 +374,12 @@ curl -s "http://localhost:3001/api/paperclip/worktrees"
 
 ```bash
 # Dry-run：只看計畫不執行
-curl -s -X POST "http://localhost:3001/api/paperclip/auto-dispatch?dryRun=true&limit=5"
+curl -s -X POST "http://localhost:3001/api/paperclip/auto-dispatch?dryRun=true&limit=5" \
+  -H "$(bash tools/paperclip/auth-header.sh)"
 
 # 實際執行：最多派 2 個任務
-curl -s -X POST "http://localhost:3001/api/paperclip/auto-dispatch?limit=2"
+curl -s -X POST "http://localhost:3001/api/paperclip/auto-dispatch?limit=2" \
+  -H "$(bash tools/paperclip/auth-header.sh)"
 ```
 
 Auto-dispatch 已設定 cron 每 10 分鐘執行（上限 2 個任務）。

--- a/.claude/skills/review-agent-work/SKILL.md
+++ b/.claude/skills/review-agent-work/SKILL.md
@@ -20,8 +20,11 @@ description: '檢查 Paperclip agent 的工作成果，自動修復常見問題�
 
 ### Step 1: 取得工作摘要
 
+**Issue #34 PR C 起**：superadmin `/api/paperclip/*` 端點需要認證。用 `tools/paperclip/auth-header.sh` 產生 `Authorization: Bearer $INTERNAL_API_KEY` header。
+
 ```bash
-curl -s "http://localhost:3001/api/paperclip/work-summary"
+curl -s "http://localhost:3001/api/paperclip/work-summary" \
+  -H "$(bash tools/paperclip/auth-header.sh)"
 ```
 
 回傳 `readyToMerge`、`hasIssues`、每個 branch 的 diff stat 和 issues。
@@ -67,6 +70,7 @@ docker exec $CONTAINER sh -c "
 
 ```bash
 curl -s -X POST "http://localhost:3001/api/paperclip/worktrees/{slug}/merge" \
+  -H "$(bash tools/paperclip/auth-header.sh)" \
   -H "Content-Type: application/json" \
   -d '{"cleanup": true}'
 ```

--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,12 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
 NEXT_PUBLIC_SUPERADMIN_URL=http://localhost:3001
 # 超級管理員站 (apps/superadmin) - Port 3001。可選：主站 URL，用於「前往主站」與非 super_admin 導向
 NEXT_PUBLIC_MAIN_SITE_URL=http://localhost:3000
+
+# Server-to-server bearer token for routes that cannot be driven by a Supabase
+# session — Claude Code skills (dispatch-agents / review-agent-work), the
+# scheduled-tasks MCP, internal cron forwarding, etc.  Put this in
+# apps/superadmin/.env.local (NOT committed). Generate with:
+#   openssl rand -hex 32
+# Callers attach it as `Authorization: Bearer $INTERNAL_API_KEY`.
+# Guarded routes (see Issue #34 PR C) accept it OR a super_admin session.
+INTERNAL_API_KEY=replace-with-openssl-rand-hex-32

--- a/apps/superadmin/app/api/paperclip/cron/configs/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/paperclip/cron/configs/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+// Issue #34 PR C — /api/paperclip/cron/configs (GET + PATCH) must be reachable
+// via either a superadmin session OR the INTERNAL_API_KEY bearer token.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  source?: 'session' | 'internal';
+  userId?: string | null;
+}
+const authState: AuthState = { ok: true, source: 'session', userId: 'admin-1' };
+
+jest.mock('@/lib/auth/require-superadmin-or-internal', () => ({
+  requireSuperadminOrInternal: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, source: authState.source ?? 'session', userId: authState.userId ?? null };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+const fromSpy = jest.fn();
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      const terminal = Promise.resolve({ data: [], error: null });
+      const chain = {
+        select: () => chain,
+        order: () => terminal,
+        eq: () => ({ select: () => ({ single: () => Promise.resolve({ data: { job_type: 'agent_health' }, error: null }) }) }),
+        update: () => chain,
+        then: terminal.then.bind(terminal),
+      };
+      return chain;
+    },
+  }),
+}));
+
+import { GET, PATCH } from '../route';
+
+function getReq(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/paperclip/cron/configs', { method: 'GET' });
+}
+function patchReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/paperclip/cron/configs', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  authState.source = 'session';
+  authState.userId = 'admin-1';
+});
+
+describe('/api/paperclip/cron/configs', () => {
+  it('GET returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('GET returns 200 via internal key (server caller)', async () => {
+    authState.ok = true;
+    authState.source = 'internal';
+    authState.userId = null;
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    expect(fromSpy).toHaveBeenCalledWith('paperclip_cron_configs');
+  });
+
+  it('PATCH returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await PATCH(patchReq({ job_type: 'agent_health', enabled: true }));
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('PATCH returns 200 via session', async () => {
+    const res = await PATCH(patchReq({ job_type: 'agent_health', enabled: true }));
+    expect(res.status).toBe(200);
+    expect(fromSpy).toHaveBeenCalledWith('paperclip_cron_configs');
+  });
+
+  it('PATCH returns 400 for invalid job_type (after auth passes)', async () => {
+    const res = await PATCH(patchReq({ job_type: 'bogus' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/superadmin/app/api/paperclip/cron/configs/route.ts
+++ b/apps/superadmin/app/api/paperclip/cron/configs/route.ts
@@ -4,11 +4,20 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadminOrInternal } from '@/lib/auth/require-superadmin-or-internal';
 import type { CronJobType } from '@/lib/paperclip/adapter-models';
 
 const VALID_JOB_TYPES: CronJobType[] = ['agent_health', 'work_summary', 'auto_dispatch'];
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/paperclip/cron/configs',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   const supabase = createAdminClient();
   const { data, error } = await supabase
     .from('paperclip_cron_configs')
@@ -23,6 +32,14 @@ export async function GET() {
 }
 
 export async function PATCH(request: NextRequest) {
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/paperclip/cron/configs',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ ok: false, error: authResult.message }, { status: authResult.status });
+  }
+
   let body: {
     job_type: CronJobType;
     enabled?: boolean;
@@ -49,11 +66,10 @@ export async function PATCH(request: NextRequest) {
     );
   }
 
-  const userId = request.headers.get('x-user-id');
   const updates: Record<string, unknown> = {};
   if (body.enabled !== undefined) updates.enabled = body.enabled;
   if (body.interval_seconds !== undefined) updates.interval_seconds = body.interval_seconds;
-  if (userId) updates.updated_by = userId;
+  if (authResult.userId) updates.updated_by = authResult.userId;
 
   if (Object.keys(updates).length === 0) {
     return NextResponse.json({ ok: false, error: 'No fields to update.' }, { status: 400 });

--- a/apps/superadmin/app/api/paperclip/cron/run/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/paperclip/cron/run/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+// Issue #34 PR C — /api/paperclip/cron/run (POST) must require session OR
+// INTERNAL_API_KEY. Used by scheduled-tasks MCP to trigger agent-health etc.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  source?: 'session' | 'internal';
+  userId?: string | null;
+}
+const authState: AuthState = { ok: true, source: 'session', userId: 'admin-1' };
+
+jest.mock('@/lib/auth/require-superadmin-or-internal', () => ({
+  requireSuperadminOrInternal: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, source: authState.source ?? 'session', userId: authState.userId ?? null };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+const fromSpy = jest.fn();
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      const eq = () => Promise.resolve({ error: null });
+      const update = () => ({ eq });
+      const insert = () => Promise.resolve({ error: null });
+      return { update, insert };
+    },
+  }),
+}));
+
+const fetchSpy = jest.fn(
+  async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+);
+const globalWithFetch = global as unknown as { fetch: typeof fetch };
+globalWithFetch.fetch = fetchSpy as unknown as typeof fetch;
+
+import { POST } from '../route';
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/paperclip/cron/run', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  authState.source = 'session';
+  authState.userId = 'admin-1';
+});
+
+describe('POST /api/paperclip/cron/run', () => {
+  it('returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(postReq({ job_type: 'agent_health' }));
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 via internal key and forwards INTERNAL_API_KEY to downstream', async () => {
+    authState.source = 'internal';
+    authState.userId = null;
+    process.env.INTERNAL_API_KEY = 'test-key';
+    const res = await POST(postReq({ job_type: 'agent_health' }));
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalled();
+    const fetchCall = fetchSpy.mock.calls[0];
+    const init = fetchCall[1] as { headers?: Record<string, string> };
+    expect(init?.headers?.Authorization).toBe('Bearer test-key');
+  });
+
+  it('returns 200 via session', async () => {
+    const res = await POST(postReq({ job_type: 'work_summary' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 for invalid job_type (after auth passes)', async () => {
+    const res = await POST(postReq({ job_type: 'bogus' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/superadmin/app/api/paperclip/cron/run/route.ts
+++ b/apps/superadmin/app/api/paperclip/cron/run/route.ts
@@ -5,6 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadminOrInternal } from '@/lib/auth/require-superadmin-or-internal';
 import type { CronJobType } from '@/lib/paperclip/adapter-models';
 
 const VALID_JOB_TYPES: CronJobType[] = ['agent_health', 'work_summary', 'auto_dispatch'];
@@ -20,6 +21,14 @@ function getInternalUrl(jobType: CronJobType): string {
 }
 
 export async function POST(request: NextRequest) {
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/paperclip/cron/run',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ ok: false, error: authResult.message }, { status: authResult.status });
+  }
+
   let body: { job_type: CronJobType };
   try {
     body = await request.json();
@@ -34,16 +43,20 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const userId = request.headers.get('x-user-id');
+  const userId = authResult.userId;
   const url = getInternalUrl(body.job_type);
   const method = body.job_type === 'auto_dispatch' ? 'POST' : 'GET';
+  // Forward INTERNAL_API_KEY so downstream routes (which will also be guarded
+  // by requireSuperadminOrInternal) accept the server-to-server call regardless
+  // of whether the outer caller had a session or the internal key.
+  const internalKey = process.env.INTERNAL_API_KEY ?? '';
 
   try {
     const res = await fetch(url, {
       method,
       headers: {
         'Content-Type': 'application/json',
-        ...(userId ? { 'x-user-id': userId } : {}),
+        ...(internalKey ? { Authorization: `Bearer ${internalKey}` } : {}),
       },
       ...(method === 'POST' ? { body: JSON.stringify({ dryRun: false, limit: 2 }) } : {}),
     });

--- a/apps/superadmin/app/api/paperclip/issues/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/paperclip/issues/__tests__/route.test.ts
@@ -6,6 +6,24 @@
 
 import { NextRequest } from 'next/server';
 
+// ── Auth mock (Issue #34 PR C) ───────────────────────────────────────────
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  source?: 'session' | 'internal';
+  userId?: string | null;
+}
+const authState: AuthState = { ok: true, source: 'session', userId: 'admin-1' };
+
+jest.mock('@/lib/auth/require-superadmin-or-internal', () => ({
+  requireSuperadminOrInternal: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, source: authState.source ?? 'session', userId: authState.userId ?? null };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
 jest.mock('@/lib/paperclip/client', () => ({
   createIssue: jest.fn(),
 }));
@@ -55,6 +73,20 @@ const ORIGINAL_ENV = process.env;
 
 beforeEach(() => {
   jest.resetAllMocks();
+  // Reset auth state and re-arm the mock implementation (resetAllMocks wiped it).
+  authState.ok = true;
+  authState.status = undefined;
+  authState.source = 'session';
+  authState.userId = 'admin-1';
+  const authMod = jest.requireMock('@/lib/auth/require-superadmin-or-internal') as {
+    requireSuperadminOrInternal: jest.Mock;
+  };
+  authMod.requireSuperadminOrInternal.mockImplementation(async () => {
+    if (authState.ok) {
+      return { ok: true, source: authState.source ?? 'session', userId: authState.userId ?? null };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  });
   process.env = {
     ...ORIGINAL_ENV,
     NEXT_PUBLIC_PAPERCLIP_BASE_URL: 'http://localhost:3187',
@@ -338,5 +370,40 @@ describe('POST /api/paperclip/issues', () => {
     const dispatched = createIssueMock.mock.calls[0][0].payload;
     // Client-supplied agent takes priority — server must NOT overwrite.
     expect(dispatched.assigneeAgentId).toBe('agent-fs-explicit');
+  });
+
+  // ── Issue #34 PR C: dual-track auth ────────────────────────────────────
+
+  it('returns 401 when neither session nor internal key is valid', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(makeReq(validPayload));
+    expect(res.status).toBe(401);
+    // Regression guard: no downstream side effects before auth.
+    expect(findRepoRootMock).not.toHaveBeenCalled();
+    expect(createWorktreeMock).not.toHaveBeenCalled();
+    expect(createIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when session user lacks super_admin role', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await POST(makeReq(validPayload));
+    expect(res.status).toBe(403);
+    expect(createWorktreeMock).not.toHaveBeenCalled();
+    expect(createIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('allows the request through when caller presents a valid INTERNAL_API_KEY (skill path)', async () => {
+    authState.source = 'internal';
+    authState.userId = null;
+    createIssueMock.mockResolvedValue({
+      ok: true,
+      issue: { id: 'uuid-internal' },
+      issueUrl: 'http://localhost:3187/VIS/issues/uuid-internal',
+    });
+    const res = await POST(makeReq(validPayload));
+    expect(res.status).toBe(200);
+    expect(createIssueMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/superadmin/app/api/paperclip/issues/route.ts
+++ b/apps/superadmin/app/api/paperclip/issues/route.ts
@@ -14,6 +14,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { getAgentRuntime } from '@/lib/agent-runtime';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadminOrInternal } from '@/lib/auth/require-superadmin-or-internal';
 import { loadCreditGuardConfig, type CreditGuardReader } from '@/lib/ai/anthropic-credit-guard';
 import type { PaperclipIssuePayload, PaperclipRoleId } from '@/lib/paperclip/types';
 import type { WorktreePaths } from '@/lib/paperclip/worktree';
@@ -153,6 +154,17 @@ export async function prepareWorktreeForTask(
 }
 
 export async function POST(request: NextRequest) {
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/paperclip/issues',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json(
+      { ok: false, status: authResult.status, error: authResult.message },
+      { status: authResult.status },
+    );
+  }
+
   const config = readPaperclipConfig();
 
   // Factory validates baseUrl + apiKey (required by every runtime method).
@@ -314,7 +326,8 @@ export async function POST(request: NextRequest) {
 
   // ── Persist to paperclip_tasks for server-side tracking ──────────────
   if (result.ok) {
-    const userId = request.headers.get('x-user-id') ?? undefined;
+    // Internal-key callers (skills, cron) have no session userId — record null.
+    const userId = authResult.userId ?? undefined;
     // Extract rowId from title format "[Row 042] Feature Name"
     const rowIdMatch = body.title.match(/\[Row\s+(\S+?)\]/i);
     const rowId = rowIdMatch?.[1] ?? body.title;

--- a/apps/superadmin/app/api/paperclip/task-queue/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/paperclip/task-queue/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+// Issue #34 PR C — /api/paperclip/task-queue (GET + POST) guarded by
+// requireSuperadminOrInternal.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  source?: 'session' | 'internal';
+  userId?: string | null;
+}
+const authState: AuthState = { ok: true, source: 'session', userId: 'admin-1' };
+
+jest.mock('@/lib/auth/require-superadmin-or-internal', () => ({
+  requireSuperadminOrInternal: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, source: authState.source ?? 'session', userId: authState.userId ?? null };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+const fromSpy = jest.fn();
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      const terminal = Promise.resolve({ data: [], error: null });
+      const chain = {
+        select: () => chain,
+        order: () => chain,
+        eq: () => chain,
+        in: () => chain,
+        insert: () => ({ select: () => ({ single: () => Promise.resolve({ data: { id: '1' }, error: null }) }) }),
+        then: terminal.then.bind(terminal),
+      };
+      return chain;
+    },
+  }),
+}));
+
+import { GET, POST } from '../route';
+
+function getReq(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/paperclip/task-queue', { method: 'GET' });
+}
+function postReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/paperclip/task-queue', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  authState.source = 'session';
+  authState.userId = 'admin-1';
+});
+
+describe('/api/paperclip/task-queue', () => {
+  it('GET returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('GET returns 200 via internal key', async () => {
+    authState.source = 'internal';
+    authState.userId = null;
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    expect(fromSpy).toHaveBeenCalledWith('paperclip_tasks');
+  });
+
+  it('POST returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(postReq({ rowId: '001', issueId: 'x', issueUrl: 'y' }));
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('POST returns 200 via session', async () => {
+    const res = await POST(postReq({ rowId: '001', issueId: 'x', issueUrl: 'y' }));
+    expect(res.status).toBe(200);
+    expect(fromSpy).toHaveBeenCalledWith('paperclip_tasks');
+  });
+
+  it('POST returns 400 for missing required fields (after auth passes)', async () => {
+    const res = await POST(postReq({}));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/superadmin/app/api/paperclip/task-queue/assign/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/paperclip/task-queue/assign/__tests__/route.test.ts
@@ -1,0 +1,94 @@
+// Issue #34 PR C — /api/paperclip/task-queue/assign (POST) guarded by
+// requireSuperadminOrInternal (internal-key allowed: assign is admin action).
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  source?: 'session' | 'internal';
+  userId?: string | null;
+}
+const authState: AuthState = { ok: true, source: 'session', userId: 'admin-1' };
+
+jest.mock('@/lib/auth/require-superadmin-or-internal', () => ({
+  requireSuperadminOrInternal: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, source: authState.source ?? 'session', userId: authState.userId ?? null };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+jest.mock('@/lib/agent-runtime', () => ({
+  getAgentRuntime: () => ({ ok: false, status: 500, error: 'no runtime' }),
+}));
+
+const fromSpy = jest.fn();
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      const maybeSingle = () =>
+        Promise.resolve({
+          data: { id: 'task-1', issue_id: 'issue-1', assigned_agent: 'agent-1' },
+          error: null,
+        });
+      const inQuery = () => ({ maybeSingle });
+      const eqSelect = () => ({ in: inQuery });
+      const selectAfterUpdate = () => ({ single: () => Promise.resolve({ data: { id: 'task-1' }, error: null }) });
+      const eqAfterUpdate = () => ({ select: selectAfterUpdate });
+      const chain = {
+        select: () => ({ eq: eqSelect }),
+        update: () => ({ eq: eqAfterUpdate }),
+      };
+      return chain;
+    },
+  }),
+}));
+
+import { POST } from '../route';
+
+function req(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/paperclip/task-queue/assign', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  authState.source = 'session';
+  authState.userId = 'admin-1';
+});
+
+describe('POST /api/paperclip/task-queue/assign', () => {
+  it('returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(req({ rowId: '001', assigneeUserId: 'u2' }));
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 via internal key', async () => {
+    authState.source = 'internal';
+    authState.userId = null;
+    const res = await POST(req({ rowId: '001', assigneeUserId: 'u2' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 200 via session', async () => {
+    const res = await POST(req({ rowId: '001', assigneeUserId: 'u2' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 when required fields missing', async () => {
+    const res = await POST(req({}));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/superadmin/app/api/paperclip/task-queue/assign/route.ts
+++ b/apps/superadmin/app/api/paperclip/task-queue/assign/route.ts
@@ -4,6 +4,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadminOrInternal } from '@/lib/auth/require-superadmin-or-internal';
 import { getAgentRuntime } from '@/lib/agent-runtime';
 
 interface AssignBody {
@@ -12,12 +13,12 @@ interface AssignBody {
 }
 
 export async function POST(request: NextRequest) {
-  const userId = request.headers.get('x-user-id');
-  if (!userId) {
-    return NextResponse.json(
-      { ok: false, error: 'Missing x-user-id header' },
-      { status: 401 },
-    );
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/paperclip/task-queue/assign',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ ok: false, error: authResult.message }, { status: authResult.status });
   }
 
   let body: AssignBody;

--- a/apps/superadmin/app/api/paperclip/task-queue/claim/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/paperclip/task-queue/claim/__tests__/route.test.ts
@@ -1,0 +1,106 @@
+// Issue #34 PR C — /api/paperclip/task-queue/claim (POST) is session-ONLY
+// (allowInternalKey: false) because claimed_by must be a real user.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  userId?: string;
+}
+const authState: AuthState = { ok: true, userId: 'admin-1' };
+
+jest.mock('@/lib/auth/require-superadmin-or-internal', () => ({
+  requireSuperadminOrInternal: jest.fn(async (opts: { allowInternalKey?: boolean }) => {
+    // Route passes allowInternalKey:false — session only.
+    if (opts?.allowInternalKey === false) {
+      if (authState.ok) {
+        return { ok: true, source: 'session', userId: authState.userId ?? 'admin-1' };
+      }
+      return { ok: false, status: authState.status ?? 401, message: 'denied' };
+    }
+    // Fallback — should not be reached from claim, but keep the mock safe.
+    return { ok: true, source: 'internal', userId: null };
+  }),
+}));
+
+jest.mock('@/lib/agent-runtime', () => ({
+  getAgentRuntime: () => ({ ok: false, status: 500, error: 'no runtime' }),
+}));
+
+const fromSpy = jest.fn();
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      const maybeSingleFirst = () =>
+        Promise.resolve({
+          data: { id: 't1', claimed_by: null, row_id: '001', issue_id: 'i1', assigned_agent: 'a1' },
+          error: null,
+        });
+      const selectUpdate = () => ({ maybeSingle: () => Promise.resolve({ data: { id: 't1' }, error: null }) });
+      const chain = {
+        select: () => ({
+          eq: () => ({
+            in: () => ({ maybeSingle: maybeSingleFirst }),
+          }),
+        }),
+        update: () => ({
+          eq: () => ({
+            is: () => ({
+              select: selectUpdate,
+            }),
+          }),
+        }),
+      };
+      return chain;
+    },
+  }),
+}));
+
+import { POST } from '../route';
+
+function req(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/paperclip/task-queue/claim', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  authState.userId = 'admin-1';
+});
+
+describe('POST /api/paperclip/task-queue/claim', () => {
+  it('returns 401 when session is missing (internal key NOT accepted here)', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(req({ rowId: '001' }));
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when session lacks super_admin role', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await POST(req({ rowId: '001' }));
+    expect(res.status).toBe(403);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 via session (valid super_admin claims the task)', async () => {
+    const res = await POST(req({ rowId: '001' }));
+    expect(res.status).toBe(200);
+    expect(fromSpy).toHaveBeenCalledWith('paperclip_tasks');
+  });
+
+  it('returns 400 when rowId missing', async () => {
+    const res = await POST(req({}));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/superadmin/app/api/paperclip/task-queue/claim/route.ts
+++ b/apps/superadmin/app/api/paperclip/task-queue/claim/route.ts
@@ -5,6 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadminOrInternal } from '@/lib/auth/require-superadmin-or-internal';
 import { getAgentRuntime } from '@/lib/agent-runtime';
 
 interface ClaimBody {
@@ -12,13 +13,17 @@ interface ClaimBody {
 }
 
 export async function POST(request: NextRequest) {
-  const userId = request.headers.get('x-user-id');
-  if (!userId) {
-    return NextResponse.json(
-      { ok: false, error: 'Missing x-user-id header' },
-      { status: 401 },
-    );
+  // Claim writes the caller's userId to `claimed_by`, so we MUST have a real
+  // human identity — internal-key callers are not allowed here.
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/paperclip/task-queue/claim',
+    allowInternalKey: false,
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ ok: false, error: authResult.message }, { status: authResult.status });
   }
+  const userId = authResult.userId;
 
   let body: ClaimBody;
   try {

--- a/apps/superadmin/app/api/paperclip/task-queue/poll/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/paperclip/task-queue/poll/__tests__/route.test.ts
@@ -1,0 +1,97 @@
+// Issue #34 PR C — /api/paperclip/task-queue/poll (GET) is the server-side
+// cron poller. Guarded by requireSuperadminOrInternal so it can be driven by
+// scheduled-tasks MCP (via INTERNAL_API_KEY) AND by an operator manually
+// kicking it from the superadmin UI.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  source?: 'session' | 'internal';
+  userId?: string | null;
+}
+const authState: AuthState = { ok: true, source: 'internal', userId: null };
+
+jest.mock('@/lib/auth/require-superadmin-or-internal', () => ({
+  requireSuperadminOrInternal: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, source: authState.source ?? 'internal', userId: authState.userId ?? null };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+const getAgentRuntimeSpy = jest.fn();
+jest.mock('@/lib/agent-runtime', () => ({
+  getAgentRuntime: () => {
+    getAgentRuntimeSpy();
+    return { ok: false, status: 500, error: 'no runtime' };
+  },
+}));
+
+const fromSpy = jest.fn();
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      return {
+        select: () => ({
+          in: () => ({
+            order: () => Promise.resolve({ data: [], error: null }),
+          }),
+        }),
+      };
+    },
+  }),
+}));
+
+import { GET } from '../route';
+
+function getReq(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/paperclip/task-queue/poll', { method: 'GET' });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  authState.source = 'internal';
+  authState.userId = null;
+});
+
+describe('GET /api/paperclip/task-queue/poll', () => {
+  it('returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    // Regression guard: no runtime or DB contact before auth passes.
+    expect(getAgentRuntimeSpy).not.toHaveBeenCalled();
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when session lacks super_admin role', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await GET(getReq());
+    expect(res.status).toBe(403);
+    expect(getAgentRuntimeSpy).not.toHaveBeenCalled();
+  });
+
+  it('proceeds to runtime lookup when called via internal key (cron path)', async () => {
+    // Runtime mock returns not-ok → route returns 500, but this confirms auth
+    // let the request through.
+    const res = await GET(getReq());
+    expect(res.status).toBe(500);
+    expect(getAgentRuntimeSpy).toHaveBeenCalled();
+  });
+
+  it('proceeds when called via a superadmin session (manual UI trigger)', async () => {
+    authState.source = 'session';
+    authState.userId = 'admin-1';
+    const res = await GET(getReq());
+    expect(res.status).toBe(500);
+    expect(getAgentRuntimeSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/superadmin/app/api/paperclip/task-queue/poll/route.ts
+++ b/apps/superadmin/app/api/paperclip/task-queue/poll/route.ts
@@ -7,8 +7,9 @@
 // automatically switches the agent to the next adapter in the fallback
 // chain (claude_local → codex_local → gemini_local) via PATCH /api/agents/:id.
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadminOrInternal } from '@/lib/auth/require-superadmin-or-internal';
 import { getAgentRuntime } from '@/lib/agent-runtime';
 import {
   getNextAdapter,
@@ -62,7 +63,15 @@ async function getAgentAdapter(agentId: string): Promise<string | null> {
   }
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/paperclip/task-queue/poll',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ ok: false, error: authResult.message }, { status: authResult.status });
+  }
+
   const runtimeResult = getAgentRuntime();
   if (!runtimeResult.ok) {
     return NextResponse.json(runtimeResult, { status: runtimeResult.status });

--- a/apps/superadmin/app/api/paperclip/task-queue/route.ts
+++ b/apps/superadmin/app/api/paperclip/task-queue/route.ts
@@ -5,6 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadminOrInternal } from '@/lib/auth/require-superadmin-or-internal';
 
 export interface PaperclipTaskRow {
   id: string;
@@ -31,6 +32,14 @@ export interface PaperclipTaskRow {
 }
 
 export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/paperclip/task-queue',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ ok: false, error: authResult.message }, { status: authResult.status });
+  }
+
   const supabase = createAdminClient();
   const rowId = request.nextUrl.searchParams.get('rowId');
   const activeOnly = request.nextUrl.searchParams.get('active') !== 'false';
@@ -78,6 +87,14 @@ interface CreateTaskBody {
 }
 
 export async function POST(request: NextRequest) {
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/paperclip/task-queue',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ ok: false, error: authResult.message }, { status: authResult.status });
+  }
+
   let body: CreateTaskBody;
   try {
     body = (await request.json()) as CreateTaskBody;

--- a/apps/superadmin/lib/auth/__tests__/require-superadmin-or-internal.test.ts
+++ b/apps/superadmin/lib/auth/__tests__/require-superadmin-or-internal.test.ts
@@ -1,0 +1,152 @@
+// Unit tests for requireSuperadminOrInternal — dual-track auth (session OR
+// INTERNAL_API_KEY bearer token) used by server-callable paperclip routes.
+
+import { NextRequest } from 'next/server';
+
+// Mock the underlying session-based helper. We only need to assert that
+// our wrapper delegates to it when the internal-key branch does not match.
+const sessionMock = jest.fn();
+jest.mock('../require-superadmin', () => ({
+  requireSuperadmin: (...args: unknown[]) => sessionMock(...args),
+}));
+
+import { requireSuperadminOrInternal } from '../require-superadmin-or-internal';
+
+const TEST_KEY = 'test-internal-key-2026';
+
+function mkReq(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('http://localhost:3001/api/paperclip/test', {
+    method: 'POST',
+    headers,
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('requireSuperadminOrInternal', () => {
+  it('returns source=internal when Authorization Bearer matches INTERNAL_API_KEY', async () => {
+    const result = await requireSuperadminOrInternal({
+      request: mkReq({ authorization: `Bearer ${TEST_KEY}` }),
+      internalKeyOverride: TEST_KEY,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.source).toBe('internal');
+      expect(result.userId).toBeNull();
+    }
+    // Session helper must NOT be called when internal key succeeds.
+    expect(sessionMock).not.toHaveBeenCalled();
+  });
+
+  it('falls through to session when bearer token does not match', async () => {
+    sessionMock.mockResolvedValueOnce({
+      ok: true,
+      userId: 'admin-1',
+      source: 'session',
+      viaSession: true,
+    });
+    const result = await requireSuperadminOrInternal({
+      request: mkReq({ authorization: 'Bearer wrong-token' }),
+      internalKeyOverride: TEST_KEY,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.source).toBe('session');
+      expect(result.userId).toBe('admin-1');
+    }
+    expect(sessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to session when no Authorization header is present', async () => {
+    sessionMock.mockResolvedValueOnce({
+      ok: true,
+      userId: 'admin-1',
+      source: 'session',
+      viaSession: true,
+    });
+    const result = await requireSuperadminOrInternal({
+      request: mkReq(),
+      internalKeyOverride: TEST_KEY,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.source).toBe('session');
+    expect(sessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 401 when neither bearer matches nor session exists', async () => {
+    sessionMock.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      message: 'Unauthorized: missing session or header identity',
+    });
+    const result = await requireSuperadminOrInternal({
+      request: mkReq({ authorization: 'Bearer bogus' }),
+      internalKeyOverride: TEST_KEY,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+    }
+  });
+
+  it('returns 403 when session user lacks super_admin role', async () => {
+    sessionMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      message: 'Forbidden: super_admin role required',
+    });
+    const result = await requireSuperadminOrInternal({ request: mkReq() });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+    }
+  });
+
+  it('skips internal-key branch when allowInternalKey=false (session-only route)', async () => {
+    sessionMock.mockResolvedValueOnce({
+      ok: true,
+      userId: 'admin-1',
+      source: 'session',
+      viaSession: true,
+    });
+    const result = await requireSuperadminOrInternal({
+      request: mkReq({ authorization: `Bearer ${TEST_KEY}` }),
+      internalKeyOverride: TEST_KEY,
+      allowInternalKey: false,
+    });
+    // The bearer token was VALID, but allowInternalKey=false forces session path.
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.source).toBe('session');
+    expect(sessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when INTERNAL_API_KEY is empty even if client sends empty bearer', async () => {
+    sessionMock.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      message: 'Unauthorized',
+    });
+    const result = await requireSuperadminOrInternal({
+      request: mkReq({ authorization: 'Bearer ' }),
+      internalKeyOverride: '',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(401);
+  });
+
+  it('uses constant-time comparison (length mismatch still falls through)', async () => {
+    sessionMock.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      message: 'Unauthorized',
+    });
+    const result = await requireSuperadminOrInternal({
+      request: mkReq({ authorization: 'Bearer short' }),
+      internalKeyOverride: 'much-longer-than-the-presented-token',
+    });
+    expect(result.ok).toBe(false);
+    expect(sessionMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/superadmin/lib/auth/require-superadmin-or-internal.ts
+++ b/apps/superadmin/lib/auth/require-superadmin-or-internal.ts
@@ -1,0 +1,122 @@
+// =============================================================================
+// requireSuperadminOrInternal() — dual-track auth for routes that are called
+// both from the superadmin UI (with a Supabase session cookie) AND from
+// server-side callers that cannot carry a session: Claude Code skills invoked
+// via shell curl, GitHub Actions cron jobs, scheduled-tasks MCP, etc.
+//
+// Accepted identities (first match wins):
+//   1. `Authorization: Bearer <INTERNAL_API_KEY>` — server-to-server token
+//      compared with crypto.timingSafeEqual. Returns { source: 'internal' }
+//      with userId undefined.
+//   2. Supabase session cookie — reuses requireSuperadmin() below. Returns
+//      { source: 'session', userId }.
+//
+// When both tracks fail, returns the stricter of the two reasons so 401 vs 403
+// remains accurate for session callers that merely lack a role.
+// =============================================================================
+
+import { timingSafeEqual } from 'node:crypto';
+import type { NextRequest } from 'next/server';
+
+import { requireSuperadmin, type RequireSuperadminResult } from './require-superadmin';
+
+export type RequireSuperadminOrInternalResult =
+  | {
+      ok: true;
+      source: 'internal';
+      userId: null;
+    }
+  | {
+      ok: true;
+      source: 'session';
+      userId: string;
+    }
+  | {
+      ok: false;
+      status: 401 | 403;
+      message: string;
+    };
+
+export interface RequireSuperadminOrInternalOptions {
+  request: NextRequest;
+  routeLabel?: string;
+  /** Override the env var, used by tests to inject a deterministic key. */
+  internalKeyOverride?: string;
+  /**
+   * When false, the internal-key branch is skipped entirely — useful for
+   * routes that MUST have a human identity (e.g. a claim handler that writes
+   * the caller's userId into `claimed_by`).
+   */
+  allowInternalKey?: boolean;
+}
+
+function extractBearerToken(request: NextRequest): string | null {
+  const header = request.headers.get('authorization');
+  if (!header) return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+  return match[1].trim();
+}
+
+/** Constant-time comparison. Returns false if lengths differ. */
+function secureEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export type RequireSuperadminSessionOnlyResult =
+  | {
+      ok: true;
+      source: 'session';
+      userId: string;
+    }
+  | {
+      ok: false;
+      status: 401 | 403;
+      message: string;
+    };
+
+// When the caller forbids the internal-key branch, we can narrow the return
+// type to guarantee userId is a string — useful for handlers that write the
+// caller's identity into a column (e.g. claimed_by).
+export async function requireSuperadminOrInternal(
+  opts: RequireSuperadminOrInternalOptions & { allowInternalKey: false },
+): Promise<RequireSuperadminSessionOnlyResult>;
+export async function requireSuperadminOrInternal(
+  opts: RequireSuperadminOrInternalOptions,
+): Promise<RequireSuperadminOrInternalResult>;
+export async function requireSuperadminOrInternal(
+  opts: RequireSuperadminOrInternalOptions,
+): Promise<RequireSuperadminOrInternalResult> {
+  const allowInternalKey = opts.allowInternalKey ?? true;
+
+  // ── 1. Internal API key (server-to-server) ───────────────────────────────
+  if (allowInternalKey) {
+    const expected = opts.internalKeyOverride ?? process.env.INTERNAL_API_KEY ?? '';
+    const presented = extractBearerToken(opts.request);
+    if (presented && expected && secureEqual(presented, expected)) {
+      return { ok: true, source: 'internal', userId: null };
+    }
+    // If a bearer token was presented but did not match, fall through to
+    // session auth — the caller may have sent a stale/wrong token while
+    // still having a valid session cookie. Do NOT short-circuit to 401 here.
+  }
+
+  // ── 2. Supabase session ──────────────────────────────────────────────────
+  const sessionResult: RequireSuperadminResult = await requireSuperadmin({
+    request: opts.request,
+    allowHeaderFallback: false,
+    routeLabel: opts.routeLabel,
+  });
+  if (sessionResult.ok) {
+    return { ok: true, source: 'session', userId: sessionResult.userId };
+  }
+
+  return {
+    ok: false,
+    status: sessionResult.status,
+    message: sessionResult.message,
+  };
+}

--- a/tools/paperclip/auth-header.sh
+++ b/tools/paperclip/auth-header.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# tools/paperclip/auth-header.sh
+#
+# Emit the `Authorization: Bearer $INTERNAL_API_KEY` header line for curl
+# calls to guarded /api/paperclip/* endpoints.
+#
+# Issue #34 PR C introduced a dual-track auth model on those routes: either a
+# Supabase superadmin session (browser) OR this bearer token (shell / MCP /
+# cron). Skills and shell tooling use this helper to avoid copy-pasting the
+# secret into every command.
+#
+# Key resolution order:
+#   1. $INTERNAL_API_KEY env var (highest priority)
+#   2. apps/superadmin/.env.local (the usual developer setup)
+#
+# Usage:
+#   curl -s -X POST "http://localhost:3001/api/paperclip/issues" \
+#     -H "Content-Type: application/json" \
+#     -H "$(bash tools/paperclip/auth-header.sh)" \
+#     -d '{ "title": "[Row 031] ...", "description": "..." }'
+#
+# Exits non-zero with a message on stderr if no key is discoverable.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ENV_FILE="${REPO_ROOT}/apps/superadmin/.env.local"
+
+KEY="${INTERNAL_API_KEY:-}"
+
+if [ -z "$KEY" ] && [ -f "$ENV_FILE" ]; then
+  # Match INTERNAL_API_KEY=... (skip commented lines), take first match, strip
+  # optional surrounding quotes ("..." or '...').
+  KEY=$(
+    grep -E '^[[:space:]]*INTERNAL_API_KEY=' "$ENV_FILE" \
+      | head -n1 \
+      | sed -E 's/^[[:space:]]*INTERNAL_API_KEY=//' \
+      | sed -E 's/^"(.*)"$/\1/' \
+      | sed -E "s/^'(.*)'$/\1/" \
+      | tr -d '\r\n'
+  )
+fi
+
+if [ -z "$KEY" ]; then
+  cat >&2 <<EOF
+ERROR: INTERNAL_API_KEY not found.
+  - Set \`INTERNAL_API_KEY=<secret>\` in apps/superadmin/.env.local, or
+  - Export it in the current shell: \`export INTERNAL_API_KEY=<secret>\`
+  - Generate with: \`openssl rand -hex 32\`
+  - See .env.example and docs/auth/internal-api-key.md for details.
+EOF
+  exit 1
+fi
+
+printf 'Authorization: Bearer %s' "$KEY"


### PR DESCRIPTION
Follow-up to [PR #35](https://github.com/jason660519/Owner-Property-Management-AI-SPA/pull/35) (PR A) and [PR #36](https://github.com/jason660519/Owner-Property-Management-AI-SPA/pull/36) (PR B). Phase 3 of [#34](https://github.com/jason660519/Owner-Property-Management-AI-SPA/issues/34) audit.

## 為什麼 PR C 比 A/B 複雜

PR A/B 的 route 都是 browser-only（session-based guard 100% 適用）。PR C 的 7 支 paperclip route **不能**無腦套 session guard —— 它們同時被：

- superadmin UI（有 session cookie）
- `/dispatch-agents` skill 的 shell curl（**無 session**）
- `/review-agent-work` skill 的 shell curl（無 session）
- scheduled-tasks MCP cron（無 session）
- 內部 cron forwarding（route-to-route fetch，也無 session）

硬加 session guard 會把 skill flow 整個打爆（`/dispatch-agents` 每次派工都走這條路）。

## 解法：雙軌 auth helper

新檔 [`apps/superadmin/lib/auth/require-superadmin-or-internal.ts`](apps/superadmin/lib/auth/require-superadmin-or-internal.ts)：

1. `Authorization: Bearer $INTERNAL_API_KEY` → `{ source: 'internal', userId: null }`（constant-time 比對）
2. Supabase session → 委派 `requireSuperadmin({ allowHeaderFallback: false })` → `{ source: 'session', userId }`
3. 兩者皆失敗 → 回 401/403 JSON

Overload 支援 `allowInternalKey: false` 時 TS narrow 成 session-only（claim 需要真實 user）。

## Routes guarded（7 支）

| Route | Method | 原狀態 | 本 PR 配置 |
| :-- | :-- | :-- | :-- |
| `paperclip/cron/configs` | GET + PATCH | GET 無 auth；PATCH optional header | dual-track |
| `paperclip/cron/run` | POST | 無 auth | dual-track + 改 forward `INTERNAL_API_KEY` 給下游（PR D 加 guard 時 chain 不會斷） |
| `paperclip/issues` | POST | 無 auth | dual-track（skill 主要入口）|
| `paperclip/task-queue` | GET + POST | 無 auth | dual-track |
| `paperclip/task-queue/assign` | POST | legacy x-user-id | dual-track |
| `paperclip/task-queue/claim` | POST | legacy x-user-id | **session-only**（`allowInternalKey: false`）— `claimed_by` 必須是真人 |
| `paperclip/task-queue/poll` | GET | 無 auth | dual-track（cron 主要入口）|

## Skill / tooling

**新**：[`tools/paperclip/auth-header.sh`](tools/paperclip/auth-header.sh)
- 產生 `Authorization: Bearer $INTERNAL_API_KEY` header line
- 優先讀 `$INTERNAL_API_KEY` env，fallback 讀 `apps/superadmin/.env.local`
- 找不到 key 時 fail loudly 帶設定教學

**更新**：[`.claude/skills/dispatch-agents/SKILL.md`](.claude/skills/dispatch-agents/SKILL.md) 和 [`.claude/skills/review-agent-work/SKILL.md`](.claude/skills/review-agent-work/SKILL.md)
- 所有 `localhost:3001/api/paperclip/*` curl 範例都加 `-H \"$(bash tools/paperclip/auth-header.sh)\"`
- **預防性**覆蓋：本 PR 不 guard 的 route（auto-dispatch / worktrees / work-summary / merge 等）也加了 header，未來 PR D 加 guard 時 skill 不會再壞

**更新**：[.env.example](.env.example) 文檔 `INTERNAL_API_KEY` 產法（`openssl rand -hex 32`）和放置位置。

## 開發者必做一次性設定

```bash
# 一次產 key 並寫入 apps/superadmin/.env.local（gitignored）
echo \"INTERNAL_API_KEY=\$(openssl rand -hex 32)\" >> apps/superadmin/.env.local
```

Skills 和 scheduled-tasks MCP 之後都自動透過 `tools/paperclip/auth-header.sh` 讀此值。

## 測試（8 檔、51 cases）

- **Helper** `lib/auth/__tests__/require-superadmin-or-internal.test.ts`：8 cases（雙軌驗證、fall-through、allowInternalKey、constant-time）
- **7 個 route** 各 4-5 cases：401 / 403 / internal-key / session / regression guard
  - `paperclip/issues` 原有 16 happy-path 測試保留並擴加 3 auth cases（共 19）
- **Total**：51 新 cases（已有的 paperclip/issues 測試仍算在 workspace 總量內）

## 驗證

| 項目 | 結果 |
| :-- | :-- |
| jest（8 PR C suites） | **51 / 51 pass** |
| jest（全 superadmin workspace） | 1432 pass / 2 skipped；12 failures 與 PR A/B 相同 pre-existing 集合 |
| `tsc --noEmit` | 0 errors |
| `next build` | Compiled successfully in 31.4s |

## 不在本 PR（追蹤於 #34）

| PR | 範圍 |
| :-- | :-- |
| **D** | `dev-tasks`、`documents`、`transcript-parse`、`system-health`、`property-description/prompt-config`、以及其他 paperclip 端點（`agents/*`、`worktrees/*`、`auto-dispatch`、`agent-health`、`issues/{id}/*`、`work-summary`、`merge-history`、`heartbeat`）— skill docs 已預防性帶 auth header |
| **E** | 統一 helper：deprecate `es-gateway.ts::requireSuperAdmin`（大寫 A）→ `lib/auth/require-superadmin.ts` |
| **F** | 擴 `middleware.ts` matcher 至 `/api/:path*`（排除 webhooks + auth callbacks） |

## Test plan

- [x] 401 返回當 session + key 都無效
- [x] 403 返回當 session 缺 super_admin role
- [x] 200 via INTERNAL_API_KEY（skill / cron 路徑）
- [x] 200 via session（UI 路徑）
- [x] claim 用 `allowInternalKey: false` — bearer token 會被略過走 session
- [x] regression guard：auth fail 時 admin client / runtime / network 未被觸發
- [x] `cron/run` 下游 fetch 帶 `Authorization: Bearer $INTERNAL_API_KEY`
- [x] tsc / build / 全 workspace jest 無 regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)