### PR TITLE
fix(superadmin): guard 7 misc admin-client routes behind superadmin session (#34 PR D)

### DIFF
--- a/apps/superadmin/app/api/dev-tasks/[id]/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/dev-tasks/[id]/__tests__/route.test.ts
@@ -1,34 +1,51 @@
-// Issue #34 PR G — /api/dev-tasks/[id] PATCH + POST are dual-track:
-// superadmin session OR INTERNAL_API_KEY bearer (called by local-agent
-// tooling at tools/local-agent/dev-tasks-agent.ts).
-//
-// GET handler migration to session-only is tracked in PR D (separate PR),
-// so this test file does not cover GET.
+// Issue #34 PR D + PR G — /api/dev-tasks/[id]
+// - GET handler (PR D): session-only via `requireSuperadmin`.
+// - PATCH + POST handlers (PR G): dual-track via `requireSuperadminOrInternal`
+//   because they're called by local-agent tooling at
+//   tools/local-agent/dev-tasks-agent.ts, which has no session cookie.
 
 import { NextRequest } from 'next/server';
 
-interface AuthState {
+interface SessionAuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  userId?: string;
+}
+const sessionAuthState: SessionAuthState = { ok: true, userId: 'admin-1' };
+
+interface DualTrackAuthState {
   ok: boolean;
   status?: 401 | 403;
   source?: 'session' | 'internal';
   userId?: string | null;
 }
-const authState: AuthState = { ok: true, source: 'session', userId: 'admin-1' };
+const dualTrackAuthState: DualTrackAuthState = { ok: true, source: 'session', userId: 'admin-1' };
 
-jest.mock('@/lib/auth/require-superadmin-or-internal', () => ({
-  requireSuperadminOrInternal: jest.fn(async () => {
-    if (authState.ok) {
-      return { ok: true, source: authState.source ?? 'session', userId: authState.userId ?? null };
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (sessionAuthState.ok) {
+      return {
+        ok: true,
+        userId: sessionAuthState.userId ?? 'admin-1',
+        source: 'session' as const,
+        viaSession: true,
+      };
     }
-    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+    return { ok: false, status: sessionAuthState.status ?? 401, message: 'denied' };
   }),
 }));
 
-// The GET handler still reads the legacy x-user-id / resolveUserId pair on
-// this branch (PR G's sibling PR D migrates it). Mock resolveUserId so the
-// GET default import does not blow up when the module evaluates.
-jest.mock('@/lib/resolve-ai-settings-user', () => ({
-  resolveUserId: jest.fn(async (_admin: unknown, uid: string) => uid),
+jest.mock('@/lib/auth/require-superadmin-or-internal', () => ({
+  requireSuperadminOrInternal: jest.fn(async () => {
+    if (dualTrackAuthState.ok) {
+      return {
+        ok: true,
+        source: dualTrackAuthState.source ?? 'session',
+        userId: dualTrackAuthState.userId ?? null,
+      };
+    }
+    return { ok: false, status: dualTrackAuthState.status ?? 401, message: 'denied' };
+  }),
 }));
 
 const fromSpy = jest.fn();
@@ -37,18 +54,30 @@ jest.mock('@/utils/supabase/admin', () => ({
   createAdminClient: () => ({
     from: (table: string) => {
       fromSpy(table);
-      const maybeSingle = () => Promise.resolve({ data: { logs: ['old log'] }, error: null });
+      const maybeSingle = () =>
+        Promise.resolve({
+          data: { id: 'task-1', status: 'queued', logs: ['old log'] },
+          error: null,
+        });
       const update = () => ({ eq: () => Promise.resolve({ error: null }) });
       return {
-        select: () => ({ eq: () => ({ maybeSingle }) }),
+        select: () => ({
+          eq: () => ({
+            eq: () => ({ maybeSingle }),
+            maybeSingle,
+          }),
+        }),
         update,
       };
     },
   }),
 }));
 
-import { PATCH, POST } from '../route';
+import { GET, PATCH, POST } from '../route';
 
+function getReq(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/dev-tasks/task-1', { method: 'GET' });
+}
 function patchReq(body: unknown): NextRequest {
   return new NextRequest('http://localhost:3001/api/dev-tasks/task-1', {
     method: 'PATCH',
@@ -66,16 +95,43 @@ function postReq(body: unknown): NextRequest {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  authState.ok = true;
-  authState.status = undefined;
-  authState.source = 'session';
-  authState.userId = 'admin-1';
+  sessionAuthState.ok = true;
+  sessionAuthState.status = undefined;
+  sessionAuthState.userId = 'admin-1';
+  dualTrackAuthState.ok = true;
+  dualTrackAuthState.status = undefined;
+  dualTrackAuthState.source = 'session';
+  dualTrackAuthState.userId = 'admin-1';
 });
 
-describe('PATCH /api/dev-tasks/[id]', () => {
+describe('GET /api/dev-tasks/[id] (session-only)', () => {
+  it('returns 401 when auth fails', async () => {
+    sessionAuthState.ok = false;
+    sessionAuthState.status = 401;
+    const res = await GET(getReq(), { params: Promise.resolve({ id: 'task-1' }) });
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when auth fails with 403', async () => {
+    sessionAuthState.ok = false;
+    sessionAuthState.status = 403;
+    const res = await GET(getReq(), { params: Promise.resolve({ id: 'task-1' }) });
+    expect(res.status).toBe(403);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with task for super_admin', async () => {
+    const res = await GET(getReq(), { params: Promise.resolve({ id: 'task-1' }) });
+    expect(res.status).toBe(200);
+    expect(fromSpy).toHaveBeenCalledWith('dev_tasks');
+  });
+});
+
+describe('PATCH /api/dev-tasks/[id] (dual-track)', () => {
   it('returns 401 when neither session nor internal key is valid', async () => {
-    authState.ok = false;
-    authState.status = 401;
+    dualTrackAuthState.ok = false;
+    dualTrackAuthState.status = 401;
     const res = await PATCH(patchReq({ logs: ['new log'] }), {
       params: Promise.resolve({ id: 'task-1' }),
     });
@@ -84,8 +140,8 @@ describe('PATCH /api/dev-tasks/[id]', () => {
   });
 
   it('accepts internal-key caller (local-agent path)', async () => {
-    authState.source = 'internal';
-    authState.userId = null;
+    dualTrackAuthState.source = 'internal';
+    dualTrackAuthState.userId = null;
     const res = await PATCH(patchReq({ logs: ['new log'] }), {
       params: Promise.resolve({ id: 'task-1' }),
     });
@@ -108,10 +164,10 @@ describe('PATCH /api/dev-tasks/[id]', () => {
   });
 });
 
-describe('POST /api/dev-tasks/[id]', () => {
+describe('POST /api/dev-tasks/[id] (dual-track)', () => {
   it('returns 401 when neither session nor internal key is valid', async () => {
-    authState.ok = false;
-    authState.status = 401;
+    dualTrackAuthState.ok = false;
+    dualTrackAuthState.status = 401;
     const res = await POST(postReq({ status: 'succeeded' }), {
       params: Promise.resolve({ id: 'task-1' }),
     });
@@ -120,8 +176,8 @@ describe('POST /api/dev-tasks/[id]', () => {
   });
 
   it('accepts internal-key caller and marks the task complete', async () => {
-    authState.source = 'internal';
-    authState.userId = null;
+    dualTrackAuthState.source = 'internal';
+    dualTrackAuthState.userId = null;
     const res = await POST(
       postReq({ status: 'succeeded', resultSummary: { ok: true } }),
       { params: Promise.resolve({ id: 'task-1' }) },

--- a/apps/superadmin/app/api/dev-tasks/[id]/route.ts
+++ b/apps/superadmin/app/api/dev-tasks/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
-import { resolveUserId } from '@/lib/resolve-ai-settings-user';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import { requireSuperadminOrInternal } from '@/lib/auth/require-superadmin-or-internal';
 
 type DevTaskStatus = 'queued' | 'running' | 'succeeded' | 'failed';
@@ -14,17 +14,18 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/dev-tasks/[id]',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+  const userId = authResult.userId;
+
   try {
     const supabase = createAdminClient();
-    const requestedUserId = request.headers.get('x-user-id');
-    if (!requestedUserId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const userId = await resolveUserId(supabase, requestedUserId);
-    if (!userId) {
-      return NextResponse.json({ error: '找不到可用的使用者' }, { status: 401 });
-    }
 
     const { id: taskId } = await context.params;
     if (!taskId) {

--- a/apps/superadmin/app/api/dev-tasks/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/dev-tasks/__tests__/route.test.ts
@@ -1,0 +1,118 @@
+// Issue #34 PR D — /api/dev-tasks (GET + POST) migrated off legacy
+// x-user-id header to session-based auth.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  userId?: string;
+}
+const authState: AuthState = { ok: true, userId: 'admin-1' };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return {
+        ok: true,
+        userId: authState.userId ?? 'admin-1',
+        source: 'session' as const,
+        viaSession: true,
+      };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+const fromSpy = jest.fn();
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      const terminal = Promise.resolve({ data: [], error: null });
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        order: () => chain,
+        limit: () => chain,
+        insert: () => ({
+          select: () => ({
+            single: () => Promise.resolve({ data: { id: 'task-1', status: 'queued' }, error: null }),
+          }),
+        }),
+        then: terminal.then.bind(terminal),
+      };
+      return chain;
+    },
+  }),
+}));
+
+import { GET, POST } from '../route';
+
+function getReq(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/dev-tasks', { method: 'GET' });
+}
+function postReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/dev-tasks', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+});
+
+describe('/api/dev-tasks', () => {
+  it('GET returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(getReq());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('GET returns 200 and lists tasks for super_admin', async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    expect(fromSpy).toHaveBeenCalledWith('dev_tasks');
+  });
+
+  it('POST returns 401 when auth fails (regression guard)', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(
+      postReq({
+        rowId: 'R01',
+        featureName: 'feat',
+        ide: 'Cursor',
+        prompt: 'hello',
+      }),
+    );
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('POST returns 201 when all fields valid and auth passes', async () => {
+    const res = await POST(
+      postReq({
+        rowId: 'R01',
+        featureName: 'feat',
+        ide: 'Cursor',
+        prompt: 'hello',
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.taskId).toBe('task-1');
+  });
+
+  it('POST returns 400 when required fields missing', async () => {
+    const res = await POST(postReq({ ide: 'Cursor' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/superadmin/app/api/dev-tasks/route.ts
+++ b/apps/superadmin/app/api/dev-tasks/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
-import { resolveUserId } from '@/lib/resolve-ai-settings-user';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 type IDEType = 'Cursor' | 'VSCode' | 'Antigravity' | 'Claude CLI' | 'TRAE';
 
@@ -28,18 +28,18 @@ interface DevTaskResponse {
 }
 
 export async function POST(request: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/dev-tasks',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+  const userId = authResult.userId;
+
   try {
     const supabase = createAdminClient();
-
-    const requestedUserId = request.headers.get('x-user-id');
-    if (!requestedUserId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const userId = await resolveUserId(supabase, requestedUserId);
-    if (!userId) {
-      return NextResponse.json({ error: '找不到可用的使用者' }, { status: 401 });
-    }
 
     const body = (await request.json()) as unknown;
 
@@ -106,18 +106,18 @@ export async function POST(request: NextRequest) {
 
 // Optional: list tasks for current user (e.g. by rowId) for history view.
 export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/dev-tasks',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+  const userId = authResult.userId;
+
   try {
     const supabase = createAdminClient();
-
-    const requestedUserId = request.headers.get('x-user-id');
-    if (!requestedUserId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const userId = await resolveUserId(supabase, requestedUserId);
-    if (!userId) {
-      return NextResponse.json({ tasks: [] });
-    }
 
     const url = request.nextUrl;
     const rowId = url.searchParams.get('rowId');

--- a/apps/superadmin/app/api/documents/upload-condition-pdf/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/documents/upload-condition-pdf/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+// Issue #34 PR D — /api/documents/upload-condition-pdf (POST) must require a
+// super_admin session. Previously was completely no-auth, letting anyone
+// upload PDFs into the property-documents storage bucket.
+//
+// This test focuses on the auth guard — happy-path upload goes through
+// `request.formData()` which is not exercised in jest's undici-backed
+// NextRequest (multipart parsing differs). That path is covered by the
+// upload page's own integration tests.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+}
+const authState: AuthState = { ok: true };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, userId: 'admin-1', source: 'session' as const, viaSession: true };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+const uploadSpy = jest.fn();
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    storage: {
+      from: () => ({
+        upload: (...args: unknown[]) => {
+          uploadSpy(...args);
+          return Promise.resolve({ error: null });
+        },
+      }),
+    },
+  }),
+}));
+
+import { POST } from '../route';
+
+function emptyReq(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/documents/upload-condition-pdf', {
+    method: 'POST',
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+});
+
+describe('POST /api/documents/upload-condition-pdf', () => {
+  it('returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(emptyReq());
+    expect(res.status).toBe(401);
+    expect(uploadSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when auth fails with 403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await POST(emptyReq());
+    expect(res.status).toBe(403);
+    expect(uploadSpy).not.toHaveBeenCalled();
+  });
+
+  it('regression guard: storage.upload is never called when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    await POST(emptyReq());
+    expect(uploadSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/superadmin/app/api/documents/upload-condition-pdf/route.ts
+++ b/apps/superadmin/app/api/documents/upload-condition-pdf/route.ts
@@ -2,8 +2,18 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 export async function POST(req: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/documents/upload-condition-pdf',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   try {
     const formData = await req.formData();
     const file = formData.get('file') as File | null;

--- a/apps/superadmin/app/api/property-description/prompt-config/route.test.ts
+++ b/apps/superadmin/app/api/property-description/prompt-config/route.test.ts
@@ -1,23 +1,30 @@
-import { GET } from './route';
-import { createClient } from '@/utils/supabase/server';
-import { createAdminClient } from '@/utils/supabase/admin';
-import { resolveUserId } from '@/lib/resolve-ai-settings-user';
+// Issue #34 PR D — /api/property-description/prompt-config (GET) must require
+// a super_admin session. Prior to PR D this route used its own
+// `resolveEffectiveUserId` helper that did session lookup + resolveUserId
+// fallback; both are replaced with requireSuperadmin({ allowHeaderFallback: false }).
 
-jest.mock('@/utils/supabase/server', () => ({
-  createClient: jest.fn(),
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  userId?: string;
+}
+const authState: AuthState = { ok: true, userId: 'admin-1' };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return {
+        ok: true,
+        userId: authState.userId ?? 'admin-1',
+        source: 'session' as const,
+        viaSession: true,
+      };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
 }));
-
-jest.mock('@/utils/supabase/admin', () => ({
-  createAdminClient: jest.fn(),
-}));
-
-jest.mock('@/lib/resolve-ai-settings-user', () => ({
-  resolveUserId: jest.fn(),
-}));
-
-const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
-const mockCreateAdminClient = createAdminClient as jest.MockedFunction<typeof createAdminClient>;
-const mockResolveUserId = resolveUserId as jest.MockedFunction<typeof resolveUserId>;
 
 function createAdminMock(options: {
   modulePrompt?: { prompt_content: string; version?: number } | null;
@@ -46,37 +53,62 @@ function createAdminMock(options: {
   };
 }
 
-describe('GET /api/property-description/prompt-config', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+const adminState: {
+  modulePrompt?: { prompt_content: string; version?: number } | null;
+  savedPrompt?: { content: string } | null;
+} = {};
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => createAdminMock(adminState),
+}));
+
+import { GET } from './route';
+
+function req(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/property-description/prompt-config', {
+    method: 'GET',
   });
+}
 
-  it('returns 401 when unauthenticated', async () => {
-    mockCreateClient.mockResolvedValue({
-      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: null } }) },
-    } as unknown as Awaited<ReturnType<typeof createClient>>);
-    mockCreateAdminClient.mockReturnValue(createAdminMock({}) as unknown as ReturnType<typeof createAdminClient>);
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  authState.userId = 'admin-1';
+  adminState.modulePrompt = null;
+  adminState.savedPrompt = null;
+});
 
-    const response = await GET();
+describe('GET /api/property-description/prompt-config', () => {
+  it('returns 401 when auth fails with 401', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const response = await GET(req());
     expect(response.status).toBe(401);
   });
 
-  it('prefers ai_system_prompt over saved/default', async () => {
-    mockCreateClient.mockResolvedValue({
-      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-user' } } }) },
-    } as unknown as Awaited<ReturnType<typeof createClient>>);
-    mockResolveUserId.mockResolvedValue('effective-user');
-    mockCreateAdminClient.mockReturnValue(
-      createAdminMock({
-        modulePrompt: { prompt_content: 'module prompt', version: 5 },
-        savedPrompt: { content: 'saved prompt' },
-      }) as unknown as ReturnType<typeof createAdminClient>,
-    );
+  it('returns 403 when auth fails with 403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const response = await GET(req());
+    expect(response.status).toBe(403);
+  });
 
-    const response = await GET();
+  it('prefers ai_system_prompt over saved/default', async () => {
+    adminState.modulePrompt = { prompt_content: 'module prompt', version: 5 };
+    adminState.savedPrompt = { content: 'saved prompt' };
+    const response = await GET(req());
     const payload = (await response.json()) as Record<string, unknown>;
+    expect(response.status).toBe(200);
     expect(payload.source).toBe('ai_system_prompt');
     expect(payload.moduleKey).toBe('property_description');
     expect(payload.version).toBe(5);
+  });
+
+  it('falls back to default when neither ai_system_prompt nor saved_prompt exists', async () => {
+    const response = await GET(req());
+    const payload = (await response.json()) as Record<string, unknown>;
+    expect(response.status).toBe(200);
+    expect(payload.source).toBe('default');
   });
 });

--- a/apps/superadmin/app/api/property-description/prompt-config/route.ts
+++ b/apps/superadmin/app/api/property-description/prompt-config/route.ts
@@ -1,7 +1,6 @@
-import { NextResponse } from 'next/server';
-import { resolveUserId } from '@/lib/resolve-ai-settings-user';
+import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
-import { createClient } from '@/utils/supabase/server';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import { DEFAULT_PROMPT, PROMPT_NAME, truncate } from '../stream/utils';
 
 type PromptSource = 'ai_system_prompt' | 'saved_prompt' | 'default';
@@ -20,23 +19,6 @@ async function getCustomPromptTemplate(
       .eq('name', PROMPT_NAME)
       .maybeSingle();
     return data?.content ?? null;
-  } catch {
-    return null;
-  }
-}
-
-async function resolveEffectiveUserId(): Promise<string | null> {
-  try {
-    const sessionClient = await createClient();
-    const {
-      data: { user },
-    } = await sessionClient.auth.getUser();
-    if (!user?.id) {
-      return null;
-    }
-
-    const adminClient = createAdminClient();
-    return await resolveUserId(adminClient, user.id);
   } catch {
     return null;
   }
@@ -67,13 +49,19 @@ async function fetchModulePrompt(
   return { template: null, moduleKey: null, version: null };
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/property-description/prompt-config',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+  const userId = authResult.userId;
+
   try {
     const adminClient = createAdminClient();
-    const userId = await resolveEffectiveUserId();
-    if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const modulePrompt = await fetchModulePrompt(adminClient, userId);
     if (modulePrompt.template) {

--- a/apps/superadmin/app/api/system-health/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/system-health/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+// Issue #34 PR D — /api/system-health (GET) must require a super_admin
+// session. Previously no-auth, exposing OS stats + disk usage + dev service
+// status + DB latency to any unauthenticated caller.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+}
+const authState: AuthState = { ok: true };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, userId: 'admin-1', source: 'session' as const, viaSession: true };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+const fromSpy = jest.fn();
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      return {
+        select: () => ({
+          limit: () => Promise.resolve({ error: null, count: 0 }),
+        }),
+      };
+    },
+  }),
+}));
+
+// Stub global fetch so dev-services probe completes quickly without real
+// network. 503 on every probe is fine — the route still returns 200.
+const fetchSpy = jest.fn(async () => new Response('', { status: 503 }));
+const globalWithFetch = global as unknown as { fetch: typeof fetch };
+globalWithFetch.fetch = fetchSpy as unknown as typeof fetch;
+
+import { GET } from '../route';
+
+function req(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/system-health', { method: 'GET' });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+});
+
+describe('GET /api/system-health', () => {
+  it('returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when auth fails with 403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await GET(req());
+    expect(res.status).toBe(403);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with snapshot for super_admin', async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('apiServer');
+    expect(body).toHaveProperty('database');
+    expect(body).toHaveProperty('cpu');
+    expect(body).toHaveProperty('memory');
+    expect(fromSpy).toHaveBeenCalled();
+  });
+
+  it('does not probe DB when auth fails (regression guard)', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/superadmin/app/api/system-health/route.ts
+++ b/apps/superadmin/app/api/system-health/route.ts
@@ -1,8 +1,9 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import os from 'node:os';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 const execAsync = promisify(exec);
 
@@ -305,7 +306,16 @@ async function getDevServicesStatus(): Promise<DevServiceStatus[]> {
   return results;
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/system-health',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   try {
     const [database, disk, allDisks, devServices] = await Promise.all([
       checkDatabase(),

--- a/apps/superadmin/app/api/transcript-parse/jobs/[id]/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/transcript-parse/jobs/[id]/__tests__/route.test.ts
@@ -1,0 +1,92 @@
+// Issue #34 PR D — /api/transcript-parse/jobs/[id] (GET) must require a
+// super_admin session. Previously no-auth, exposing transcript parse job
+// status + error messages to any caller who could guess a job UUID.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+}
+const authState: AuthState = { ok: true };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, userId: 'admin-1', source: 'session' as const, viaSession: true };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+const fromSpy = jest.fn();
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () =>
+              Promise.resolve({
+                data: {
+                  id: 'job-1',
+                  status: 'completed',
+                  phase_message: null,
+                  progress: 100,
+                  error_message: null,
+                  created_at: '2026-01-01T00:00:00Z',
+                  started_at: '2026-01-01T00:00:01Z',
+                  completed_at: '2026-01-01T00:00:10Z',
+                  property_document_id: 'doc-1',
+                },
+                error: null,
+              }),
+          }),
+        }),
+      };
+    },
+  }),
+}));
+
+import { GET } from '../route';
+
+function req(): NextRequest {
+  return new NextRequest('http://localhost:3001/api/transcript-parse/jobs/job-1', {
+    method: 'GET',
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+});
+
+describe('GET /api/transcript-parse/jobs/[id]', () => {
+  it('returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(req(), { params: Promise.resolve({ id: 'job-1' }) });
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when auth fails with 403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await GET(req(), { params: Promise.resolve({ id: 'job-1' }) });
+    expect(res.status).toBe(403);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with job snapshot for super_admin', async () => {
+    const res = await GET(req(), { params: Promise.resolve({ id: 'job-1' }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe('job-1');
+    expect(body.status).toBe('completed');
+    expect(fromSpy).toHaveBeenCalledWith('transcript_parse_jobs');
+  });
+});

--- a/apps/superadmin/app/api/transcript-parse/jobs/[id]/route.ts
+++ b/apps/superadmin/app/api/transcript-parse/jobs/[id]/route.ts
@@ -1,16 +1,26 @@
 // filepath: apps/superadmin/app/api/transcript-parse/jobs/[id]/route.ts
 // Poll job status + progress for UI (service_role read).
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function GET(
-  _request: Request,
+  request: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/transcript-parse/jobs/[id]',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   const { id } = await context.params;
   if (!id) {
     return NextResponse.json({ error: 'Missing id' }, { status: 400 });

--- a/apps/superadmin/app/api/transcript-parse/local/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/transcript-parse/local/__tests__/route.test.ts
@@ -1,0 +1,90 @@
+// Issue #34 PR D — /api/transcript-parse/local (POST) must require a
+// super_admin session. Previously no-auth. Route triggers Python CLI / HTTP
+// calls against OCR service with Supabase-downloaded PDF content.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+}
+const authState: AuthState = { ok: true };
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, userId: 'admin-1', source: 'session' as const, viaSession: true };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+const fromSpy = jest.fn();
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      return {
+        select: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({ data: { file_path: 'path.pdf' }, error: null }),
+          }),
+        }),
+      };
+    },
+    storage: {
+      from: () => ({
+        download: () => Promise.resolve({ data: null, error: { message: 'not found' } }),
+      }),
+    },
+  }),
+}));
+
+import { POST } from '../route';
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/transcript-parse/local', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  delete process.env.OCR_LOCAL_DIR;
+  delete process.env.OCR_LOCAL_URL;
+});
+
+describe('POST /api/transcript-parse/local', () => {
+  it('returns 401 when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(makeReq({ documentId: 'doc-1' }));
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when auth fails with 403', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await POST(makeReq({ documentId: 'doc-1' }));
+    expect(res.status).toBe(403);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when documentId missing (after auth)', async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('regression guard: admin client is not touched when auth fails', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(makeReq({ documentId: 'doc-1' }));
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/superadmin/app/api/transcript-parse/local/route.ts
+++ b/apps/superadmin/app/api/transcript-parse/local/route.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 import os from 'os';
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 export const runtime = 'nodejs';
 
@@ -192,6 +193,15 @@ async function callHttpService(
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest) {
+  const authResult = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/transcript-parse/local',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   let body: { documentId?: string };
   try {
     body = (await request.json()) as { documentId?: string };


### PR DESCRIPTION
Follow-up to merged PRs #35 (A), #36 (B), #37 (C). [#34](https://github.com/jason660519/Owner-Property-Management-AI-SPA/issues/34) Phase 4.

## Scope — UI-only remainder of the audit

7 admin-client handlers under dev-tasks / documents / transcript-parse /
system-health / property-description are now `requireSuperadmin({ allowHeaderFallback: false })`.

| Route | 原狀態 | 修法 |
| :-- | :-- | :-- |
| POST `/api/documents/upload-condition-pdf` | **完全無 auth** —— 任何人可往 property-documents bucket 上傳 PDF | session guard |
| GET `/api/system-health` | **完全無 auth** —— 洩漏 CPU/memory/disk/DB latency/dev services | session guard |
| GET `/api/property-description/prompt-config` | 有 session 檢查但**無 role check** | 升級為完整 super_admin guard |
| GET `/api/transcript-parse/jobs/[id]` | 完全無 auth | session guard |
| POST `/api/transcript-parse/local` | 完全無 auth —— 觸發 OCR CLI/HTTP | session guard |
| GET+POST `/api/dev-tasks` | legacy x-user-id header | session-based |
| GET `/api/dev-tasks/[id]` | legacy x-user-id header | session-based（同檔 PATCH+POST 留 PR G）|

## 不在本 PR（留 PR G）

- PATCH + POST `/api/dev-tasks/[id]` — 被 `tools/local-agent/dev-tasks-agent.ts` 呼叫，需 dual-track（session OR INTERNAL_API_KEY）
- GET `/api/dev-tasks/next` — 同上
- GET `/api/documents/[documentId]/view` — 本來就有完整 session + owner/super_admin/authorized-agent role check，未更動

## 測試（7 檔、26 cases）

每個遷移的 handler 有 `__tests__/route.test.ts` 至少涵蓋：401 / 403 / 200 / regression guard。

`documents/upload-condition-pdf` 只測 auth（401/403/regression）—— `request.formData()` 在 jest 的 undici-backed NextRequest 下多部分解析行為與 runtime 不同，happy-path 交由 upload 頁面 integration test 涵蓋。

`property-description/prompt-config/route.test.ts` 既有 2 cases 被改寫為新的 auth mock pattern（成 4 cases）。

## 驗證

| 項目 | 結果 |
| :-- | :-- |
| jest（本 PR 7 suites） | **26 / 26 pass** |
| jest（全 workspace） | 1419 pass / 2 skipped；12 failures 與 A/B/C 相同 pre-existing |
| \`tsc --noEmit\` | 0 errors |
| \`next build\` | Compiled successfully in 24.2s |

🤖 Generated with [Claude Code](https://claude.com/claude-code)