### PR TITLE
refactor(superadmin): consolidate es-gateway::requireSuperAdmin into lib/auth (#34 PR E)

### DIFF
--- a/apps/superadmin/app/api/people-db/dataset-tree/route.ts
+++ b/apps/superadmin/app/api/people-db/dataset-tree/route.ts
@@ -1,10 +1,11 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import {
   buildDatasetTree,
   type DatasetBucket,
   type DatasetMetadataOverride,
 } from '@/lib/people-db/dataset-tree';
-import { esSearch, requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { esSearch } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import { createClient } from '@/utils/supabase/server';
 
 interface EsTermsAggregationResponse {
@@ -21,9 +22,15 @@ interface EsTermsAggregationResponse {
   hits?: { total?: { value?: number } };
 }
 
-export async function GET() {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+export async function GET(request: NextRequest) {
+  const auth = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/dataset-tree',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   try {
     const response = await esSearch<EsTermsAggregationResponse>({

--- a/apps/superadmin/app/api/people-db/datasets/metadata/bulk/route.ts
+++ b/apps/superadmin/app/api/people-db/datasets/metadata/bulk/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 // Bulk upsert for dataset_metadata. Accepts a list of dataset_paths and a
 // shared patch (favorited / enabled). Used by the sources management page to
@@ -27,8 +27,14 @@ interface MetadataRow {
 }
 
 export async function POST(req: NextRequest) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/datasets/metadata/bulk',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   let payload: BulkPatchPayload;
   try {

--- a/apps/superadmin/app/api/people-db/datasets/metadata/route.ts
+++ b/apps/superadmin/app/api/people-db/datasets/metadata/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 // CRUD endpoint for dataset display overrides (rename / favorite / enable).
 // The canonical key is dataset_path — same shape as ES's keyword field so the
@@ -15,9 +15,15 @@ interface UpsertPayload {
   notes?: string | null;
 }
 
-export async function GET() {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+export async function GET(request: NextRequest) {
+  const auth = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/datasets/metadata',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const supabase = await createClient();
   const { data, error } = await supabase
@@ -33,8 +39,14 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/datasets/metadata',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   let payload: UpsertPayload;
   try {
@@ -70,8 +82,14 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/datasets/metadata',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const datasetPath = req.nextUrl.searchParams.get('dataset_path');
   if (!datasetPath) {

--- a/apps/superadmin/app/api/people-db/datasets/route.ts
+++ b/apps/superadmin/app/api/people-db/datasets/route.ts
@@ -1,5 +1,6 @@
-import { NextResponse } from 'next/server';
-import { esSearch, requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { NextRequest, NextResponse } from 'next/server';
+import { esSearch } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 // Legacy flat facet endpoint. Kept for backward compatibility with UI surfaces
 // that haven't adopted the hierarchical /dataset-tree endpoint yet.
@@ -12,9 +13,15 @@ interface FacetResponse {
   };
 }
 
-export async function GET() {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+export async function GET(request: NextRequest) {
+  const auth = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/datasets',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   try {
     const response = await esSearch<FacetResponse>({

--- a/apps/superadmin/app/api/people-db/import/jobs/[id]/process/route.ts
+++ b/apps/superadmin/app/api/people-db/import/jobs/[id]/process/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import { processImportJob } from '@/lib/people-db/import-jobs';
 
 // Worker trigger. Invoked from:
@@ -17,11 +17,17 @@ export const runtime = 'nodejs';
 export const maxDuration = 300;
 
 export async function POST(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/import/jobs/[id]/process',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const { id } = await params;
   if (!id) {

--- a/apps/superadmin/app/api/people-db/import/jobs/[id]/route.ts
+++ b/apps/superadmin/app/api/people-db/import/jobs/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import { createAdminClient } from '@/utils/supabase/admin';
 
 // GET a single job row. Used by the UI to poll status while the worker runs.
@@ -7,11 +7,17 @@ import { createAdminClient } from '@/utils/supabase/admin';
 export const runtime = 'nodejs';
 
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/import/jobs/[id]',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const { id } = await params;
   if (!id) {

--- a/apps/superadmin/app/api/people-db/import/jobs/route.ts
+++ b/apps/superadmin/app/api/people-db/import/jobs/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import {
   enqueueImportJob,
   ASYNC_THRESHOLD_BYTES,
@@ -18,8 +18,14 @@ import { createAdminClient } from '@/utils/supabase/admin';
 export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/import/jobs',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const form = await req.formData();
   const file = form.get('file');
@@ -89,7 +95,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const job = await enqueueImportJob({
-      userId: auth.user.userId,
+      userId: auth.userId,
       file,
       columnMapping,
       datasetRoot,
@@ -117,8 +123,14 @@ export async function POST(req: NextRequest) {
 }
 
 export async function GET(req: NextRequest) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/import/jobs',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const { searchParams } = new URL(req.url);
   const status = searchParams.get('status');

--- a/apps/superadmin/app/api/people-db/import/preview/route.ts
+++ b/apps/superadmin/app/api/people-db/import/preview/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import {
   dispatchParse,
   extOf,
@@ -19,8 +19,14 @@ const MAX_SAMPLE_VALUES = 8;
 const MAX_FILE_BYTES = 25 * 1024 * 1024;
 
 export async function POST(req: NextRequest) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/import/preview',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const form = await req.formData();
   const file = form.get('file');

--- a/apps/superadmin/app/api/people-db/import/submit/route.ts
+++ b/apps/superadmin/app/api/people-db/import/submit/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { randomUUID } from 'node:crypto';
-import { requireSuperAdmin, esBulkIndex } from '@/lib/people-db/es-gateway';
+import { esBulkIndex } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import { mapRowsToDocuments } from '@/lib/people-db/import-mapper';
 import {
   dispatchParse,
@@ -21,8 +22,14 @@ const MAX_FILE_BYTES = 25 * 1024 * 1024;
 const BULK_CHUNK_SIZE = 500;
 
 export async function POST(req: NextRequest) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/import/submit',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const form = await req.formData();
   const file = form.get('file');

--- a/apps/superadmin/app/api/people-db/ingest/files/route.ts
+++ b/apps/superadmin/app/api/people-db/ingest/files/route.ts
@@ -11,7 +11,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import { createAdminClient } from '@/utils/supabase/admin';
 
 const ALLOWED_STATUSES = new Set([
@@ -32,8 +32,14 @@ const DEFAULT_PAGE_SIZE = 20;
 const MAX_PAGE_SIZE = 100;
 
 export async function GET(req: NextRequest) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/ingest/files',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const url = new URL(req.url);
   const status = url.searchParams.get('status');

--- a/apps/superadmin/app/api/people-db/ingest/retry/[fileId]/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/people-db/ingest/retry/[fileId]/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 // Row 145 Sprint 6 — POST /api/people-db/ingest/retry/[fileId] route tests.
 // Covers tdd-spec §6.3: 4 cases (auth / happy path / not found / wrong state).
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 
 // --- Mocks -----------------------------------------------------------------
 
@@ -12,17 +12,20 @@ interface AuthState {
 }
 const authState: AuthState = { ok: true, userId: 'admin-1' };
 
-jest.mock('@/lib/people-db/es-gateway', () => ({
-  requireSuperAdmin: async () => {
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: async () => {
     if (authState.ok) {
-      return { ok: true, user: { userId: authState.userId ?? 'admin-1' } };
+      return {
+        ok: true,
+        userId: authState.userId ?? 'admin-1',
+        source: 'session' as const,
+        viaSession: true,
+      };
     }
     return {
       ok: false,
-      response: NextResponse.json(
-        { detail: authState.responseStatus === 403 ? 'Forbidden' : 'Unauthorized' },
-        { status: authState.responseStatus ?? 401 },
-      ),
+      status: (authState.responseStatus ?? 401) as 401 | 403,
+      message: authState.responseStatus === 403 ? 'Forbidden' : 'Unauthorized',
     };
   },
 }));

--- a/apps/superadmin/app/api/people-db/ingest/retry/[fileId]/route.ts
+++ b/apps/superadmin/app/api/people-db/ingest/retry/[fileId]/route.ts
@@ -8,16 +8,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { createAdminClient } from '@/utils/supabase/admin';
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 const RETRIABLE_STATUSES: ReadonlySet<string> = new Set(['failed']);
 
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ fileId: string }> },
 ): Promise<NextResponse> {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/ingest/retry/[fileId]',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const { fileId } = await params;
   if (!fileId) {

--- a/apps/superadmin/app/api/people-db/ingest/runs/route.ts
+++ b/apps/superadmin/app/api/people-db/ingest/runs/route.ts
@@ -5,15 +5,21 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import { createAdminClient } from '@/utils/supabase/admin';
 
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/ingest/runs',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const url = new URL(req.url);
   const limit = Number(url.searchParams.get('limit') ?? DEFAULT_LIMIT);

--- a/apps/superadmin/app/api/people-db/ingest/stage-counts/route.ts
+++ b/apps/superadmin/app/api/people-db/ingest/stage-counts/route.ts
@@ -7,9 +7,9 @@
 // counts (one per known status). N=11 is small and every call uses
 // the status b-tree index, so this stays cheap even at M-row scale.
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import { createAdminClient } from '@/utils/supabase/admin';
 
 const STATUSES = [
@@ -28,9 +28,15 @@ const STATUSES = [
 
 type StatusKey = (typeof STATUSES)[number];
 
-export async function GET(): Promise<NextResponse> {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/ingest/stage-counts',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const db = createAdminClient();
 

--- a/apps/superadmin/app/api/people-db/merge-candidates/[id]/confirm/route.ts
+++ b/apps/superadmin/app/api/people-db/merge-candidates/[id]/confirm/route.ts
@@ -6,18 +6,24 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import {
   confirmCandidate,
   CandidateStateError,
 } from '@/lib/people-db/merge-candidates';
 
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/merge-candidates/[id]/confirm',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const { id } = await params;
   if (!id) {
@@ -26,7 +32,7 @@ export async function POST(
 
   const supabase = createAdminClient();
   try {
-    await confirmCandidate(supabase, id, auth.user.userId);
+    await confirmCandidate(supabase, id, auth.userId);
   } catch (err) {
     if (err instanceof CandidateStateError) {
       return NextResponse.json({ ok: false, error: err.message }, { status: 409 });

--- a/apps/superadmin/app/api/people-db/merge-candidates/[id]/reject/route.ts
+++ b/apps/superadmin/app/api/people-db/merge-candidates/[id]/reject/route.ts
@@ -6,18 +6,24 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import {
   rejectCandidate,
   CandidateStateError,
 } from '@/lib/people-db/merge-candidates';
 
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/merge-candidates/[id]/reject',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const { id } = await params;
   if (!id) {
@@ -26,7 +32,7 @@ export async function POST(
 
   const supabase = createAdminClient();
   try {
-    await rejectCandidate(supabase, id, auth.user.userId);
+    await rejectCandidate(supabase, id, auth.userId);
   } catch (err) {
     if (err instanceof CandidateStateError) {
       return NextResponse.json({ ok: false, error: err.message }, { status: 409 });

--- a/apps/superadmin/app/api/people-db/merge-candidates/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/people-db/merge-candidates/__tests__/route.test.ts
@@ -2,7 +2,6 @@
 // Covers the three endpoints: GET list / POST confirm / POST reject.
 
 import { NextRequest } from 'next/server';
-import { NextResponse } from 'next/server';
 
 // --- Mocks -----------------------------------------------------------------
 
@@ -14,17 +13,20 @@ interface AuthState {
 
 const authState: AuthState = { ok: true, userId: 'admin-1' };
 
-jest.mock('@/lib/people-db/es-gateway', () => ({
-  requireSuperAdmin: async () => {
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: async () => {
     if (authState.ok) {
-      return { ok: true, user: { userId: authState.userId ?? 'admin-1' } };
+      return {
+        ok: true,
+        userId: authState.userId ?? 'admin-1',
+        source: 'session' as const,
+        viaSession: true,
+      };
     }
     return {
       ok: false,
-      response: NextResponse.json(
-        { detail: authState.responseStatus === 403 ? 'Forbidden' : 'Unauthorized' },
-        { status: authState.responseStatus ?? 401 },
-      ),
+      status: (authState.responseStatus ?? 401) as 401 | 403,
+      message: authState.responseStatus === 403 ? 'Forbidden' : 'Unauthorized',
     };
   },
 }));

--- a/apps/superadmin/app/api/people-db/merge-candidates/route.ts
+++ b/apps/superadmin/app/api/people-db/merge-candidates/route.ts
@@ -4,13 +4,13 @@
 // newest-first; supports ?status= + pagination + ?embed=person,staging for
 // the admin UI's left/right comparison cards (Sprint 4b).
 //
-// super_admin only — guarded by requireSuperAdmin. Reads via createAdminClient
+// super_admin only — guarded by requireSuperadmin. Reads via createAdminClient
 // so the route works even if a super_admin's session RLS evaluation is slow
 // (consistent with Row 144 convention).
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
-import { requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 const PAGE_SIZE_DEFAULT = 20;
 const PAGE_SIZE_MAX = 100;
@@ -49,8 +49,14 @@ function parseEmbed(raw: string | null): Set<EmbedToken> {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/merge-candidates',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const url = new URL(request.url);
   const statusRaw = url.searchParams.get('status') ?? 'pending';

--- a/apps/superadmin/app/api/people-db/person/[recordId]/route.ts
+++ b/apps/superadmin/app/api/people-db/person/[recordId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { esSearch, requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { esSearch } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 // Fetches a single people-database record by record_id. Used by the person
 // detail page to render the master profile before delegating relationship
@@ -39,11 +40,17 @@ interface EsResponse {
 }
 
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ recordId: string }> },
 ) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/person/[recordId]',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const { recordId } = await params;
   if (!recordId) {

--- a/apps/superadmin/app/api/people-db/related/route.ts
+++ b/apps/superadmin/app/api/people-db/related/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { esSearch, requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { esSearch } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 // Finds people linked to the given record by shared address / phone / company.
 // Used by the person-detail page's "親友關係圖譜" feature. The query pivots on
@@ -32,8 +33,14 @@ interface EsSearchResponse<T> {
 const DEFAULT_SIZE = 50;
 
 export async function GET(req: NextRequest) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/related',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const params = req.nextUrl.searchParams;
   const recordId = params.get('record_id');

--- a/apps/superadmin/app/api/people-db/search/__tests__/route-group-by.test.ts
+++ b/apps/superadmin/app/api/people-db/search/__tests__/route-group-by.test.ts
@@ -5,20 +5,31 @@
 // post-ES aggregation via aggregateByPerson after joining the hit list
 // with people_db_person_sources + people_db_persons from Supabase.
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 
 // --- Mocks -----------------------------------------------------------------
 
 const authState = { ok: true };
 
-jest.mock('@/lib/people-db/es-gateway', () => ({
-  requireSuperAdmin: async () => {
-    if (authState.ok) return { ok: true, user: { userId: 'admin-1' } };
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: async () => {
+    if (authState.ok) {
+      return {
+        ok: true,
+        userId: 'admin-1',
+        source: 'session' as const,
+        viaSession: true,
+      };
+    }
     return {
       ok: false,
-      response: NextResponse.json({ detail: 'Unauthorized' }, { status: 401 }),
+      status: 401 as const,
+      message: 'Unauthorized',
     };
   },
+}));
+
+jest.mock('@/lib/people-db/es-gateway', () => ({
   esSearch: jest.fn(),
 }));
 

--- a/apps/superadmin/app/api/people-db/search/route.ts
+++ b/apps/superadmin/app/api/people-db/search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { buildSearchBody } from '@/lib/people-db/search-strategy';
-import { esSearch, requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { esSearch } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import { createAdminClient } from '@/utils/supabase/admin';
 import {
   aggregateByPerson,
@@ -43,8 +44,14 @@ const VALID_QUALITY = new Set(['all', 'high', 'medium', 'low']);
 const VALID_GROUP_BY = new Set(['record', 'person']);
 
 export async function GET(req: NextRequest) {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+  const auth = await requireSuperadmin({
+    request: req,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/search',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   const { searchParams } = req.nextUrl;
   const q = searchParams.get('q') ?? '';

--- a/apps/superadmin/app/api/people-db/stats/route.ts
+++ b/apps/superadmin/app/api/people-db/stats/route.ts
@@ -1,5 +1,6 @@
-import { NextResponse } from 'next/server';
-import { esSearch, requireSuperAdmin } from '@/lib/people-db/es-gateway';
+import { NextRequest, NextResponse } from 'next/server';
+import { esSearch } from '@/lib/people-db/es-gateway';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 
 interface StatsResponse {
   hits?: { total?: { value?: number } | number };
@@ -10,9 +11,15 @@ interface StatsResponse {
   };
 }
 
-export async function GET() {
-  const auth = await requireSuperAdmin();
-  if (!auth.ok) return auth.response;
+export async function GET(request: NextRequest) {
+  const auth = await requireSuperadmin({
+    request,
+    allowHeaderFallback: false,
+    routeLabel: 'api/people-db/stats',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ detail: auth.message }, { status: auth.status });
+  }
 
   try {
     const response = await esSearch<StatsResponse>({

--- a/apps/superadmin/lib/people-db/es-gateway.ts
+++ b/apps/superadmin/lib/people-db/es-gateway.ts
@@ -1,53 +1,13 @@
 // Thin Elasticsearch gateway used by the Next.js route handlers in the
 // people-db feature (Row 144). The legacy FastAPI proxy has been removed as
 // part of the OpenClaw migration, so these routes talk to ES directly.
-
-import { createClient } from '@/utils/supabase/server';
-import { NextResponse } from 'next/server';
+//
+// Note: the legacy `requireSuperAdmin` helper and `AuthorizedUser` interface
+// were removed in Issue #34 PR E — callers now use `requireSuperadmin` from
+// `@/lib/auth/require-superadmin`.
 
 export const ES_URL = process.env.ELASTICSEARCH_URL ?? 'http://localhost:9200';
 export const PEOPLE_DB_INDEX = process.env.PEOPLE_DB_INDEX ?? 'people_database';
-
-export interface AuthorizedUser {
-  userId: string;
-}
-
-/**
- * Verifies that the caller is an authenticated super_admin. Returns a
- * NextResponse when access is denied so callers can early-return the rejection.
- */
-export async function requireSuperAdmin(): Promise<
-  | { ok: true; user: AuthorizedUser }
-  | { ok: false; response: NextResponse }
-> {
-  try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return { ok: false, response: NextResponse.json({ detail: 'Unauthorized' }, { status: 401 }) };
-    }
-
-    const { data: roleRows } = await supabase.rpc('get_user_roles', {
-      lookup_user_id: user.id,
-    });
-    const roles = Array.isArray(roleRows)
-      ? roleRows.map((row: { role_name: string }) => row.role_name)
-      : [];
-    const isSuperAdmin =
-      roles.includes('super_admin') || user.user_metadata?.role === 'super_admin';
-
-    if (!isSuperAdmin) {
-      return { ok: false, response: NextResponse.json({ detail: 'Forbidden' }, { status: 403 }) };
-    }
-
-    return { ok: true, user: { userId: user.id } };
-  } catch {
-    return { ok: false, response: NextResponse.json({ detail: 'Unauthorized' }, { status: 401 }) };
-  }
-}
 
 export async function esSearch<T = unknown>(body: unknown): Promise<T> {
   const res = await fetch(`${ES_URL}/${PEOPLE_DB_INDEX}/_search`, {


### PR DESCRIPTION
Follow-up to merged PRs #35–#37 (A/B/C). [#34](https://github.com/jason660519/Owner-Property-Management-AI-SPA/issues/34) Phase 5 — helper unification.

## 背景

兩個同意圖的 auth helper 並存：
- `lib/people-db/es-gateway.ts::requireSuperAdmin`（大寫 A）—— 被 20 支 people-db route 使用
- `lib/auth/require-superadmin.ts::requireSuperadmin`（小寫 admin）—— 被 PR A–D 使用

本 PR 退役前者，全倉只留一個 `requireSuperadmin(...)` 決定「是不是 super_admin」。這讓未來 auth 變更（MFA、短期 token）只有一個入口。

## 變更（24 檔）

### Helper（移除 public surface）
`apps/superadmin/lib/people-db/es-gateway.ts`：刪 `requireSuperAdmin` + `AuthorizedUser` + 已不用的 `createClient`/`NextResponse` imports。`ES_URL`、`PEOPLE_DB_INDEX`、`esSearch`、`esBulkIndex`、`EsBulkResult` 都保留。

### 20 支 people-db route
所有 handler 改呼叫：
```ts
const auth = await requireSuperadmin({
  request,
  allowHeaderFallback: false,
  routeLabel: 'api/people-db/<path>',
});
if (!auth.ok) {
  return NextResponse.json({ detail: auth.message }, { status: auth.status });
}
```
**error body shape 保留 `{ detail }`**（舊 helper 的形狀），前端錯誤解析不受影響。

Routes 清單：ingest/{retry/[fileId], runs, stage-counts, files}、dataset-tree、datasets/{root, metadata, metadata/bulk}、import/{preview, submit, jobs, jobs/[id], jobs/[id]/process}、merge-candidates/{root, [id]/confirm, [id]/reject}、person/[recordId]、related、search、stats。

### 3 支測試更新
`ingest/retry/[fileId]`、`merge-candidates`、`search/route-group-by` 的 `jest.mock` 從 `@/lib/people-db/es-gateway` 改為 `@/lib/auth/require-superadmin`，mock return 改為新 shape。

## 驗證

- `tsc --noEmit`: 0 errors
- jest（people-db suites）: 239 pass / 2 skipped — no new failures
- jest（全 workspace）: 1395 pass；12 failures 與 A/B/C/D 相同 pre-existing

## 未來

三個檔案定義自己 inline 的 `requireSuperAdmin`（signature 不同）：
- `app/superadmin/settings/evaluations-global-test/promptActions.ts`
- `app/superadmin/settings/actions.ts`
- `app/api/fp-converter/route.ts`

它們是 server action / legacy route，等 #34 A–G 全 merge 後的 follow-up PR 處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)