### PR TITLE
feat(superadmin): middleware-level /api/* defense-in-depth auth gate (#34 PR F)

### DIFF
--- a/apps/superadmin/lib/middleware/__tests__/api-auth-matcher.test.ts
+++ b/apps/superadmin/lib/middleware/__tests__/api-auth-matcher.test.ts
@@ -1,0 +1,103 @@
+// Unit tests for the defense-in-depth /api/* middleware helper (#34 PR F).
+
+import {
+  PUBLIC_API_PATHS,
+  isPublicApiPath,
+  extractBearerToken,
+  internalKeyMatches,
+  hasValidInternalKey,
+} from '../api-auth-matcher';
+
+describe('PUBLIC_API_PATHS allow-list', () => {
+  it('keeps the allow-list minimal and documented', () => {
+    // If this number grows, double-check every new entry has a real HMAC /
+    // OAuth / health reason — each one is a hole in the middleware gate.
+    expect(PUBLIC_API_PATHS.length).toBeLessThanOrEqual(4);
+    for (const entry of PUBLIC_API_PATHS) {
+      expect(entry.prefix.startsWith('/api/')).toBe(true);
+      expect(['oauth', 'hmac', 'health']).toContain(entry.reason);
+    }
+  });
+});
+
+describe('isPublicApiPath', () => {
+  it('matches OAuth callback paths', () => {
+    expect(isPublicApiPath('/api/auth/google/callback')).toBe(true);
+    expect(isPublicApiPath('/api/auth/google')).toBe(true);
+  });
+
+  it('matches webhook paths', () => {
+    expect(isPublicApiPath('/api/webhooks/paperclip')).toBe(true);
+    expect(isPublicApiPath('/api/webhooks/anything/subpath')).toBe(true);
+  });
+
+  it('matches the exact OCR callback path but not arbitrary siblings', () => {
+    expect(isPublicApiPath('/api/people-db/ingest/ocr/callback')).toBe(true);
+    // Sibling or extended paths must NOT leak through.
+    expect(isPublicApiPath('/api/people-db/ingest/ocr/callback/foo')).toBe(false);
+    expect(isPublicApiPath('/api/people-db/ingest/ocr')).toBe(false);
+    expect(isPublicApiPath('/api/people-db/ingest')).toBe(false);
+  });
+
+  it('rejects arbitrary paths that look like auth but are not', () => {
+    expect(isPublicApiPath('/api/ai-settings/keys')).toBe(false);
+    expect(isPublicApiPath('/api/iam/audit')).toBe(false);
+    expect(isPublicApiPath('/api/paperclip/issues')).toBe(false);
+    expect(isPublicApiPath('/api/supabase/sql')).toBe(false);
+  });
+
+  it('returns false for non-/api paths', () => {
+    expect(isPublicApiPath('/superadmin/dashboard')).toBe(false);
+    expect(isPublicApiPath('/')).toBe(false);
+  });
+});
+
+describe('extractBearerToken', () => {
+  it('returns the token for a well-formed Bearer header', () => {
+    expect(extractBearerToken('Bearer abc123')).toBe('abc123');
+    expect(extractBearerToken('bearer abc123')).toBe('abc123');
+    expect(extractBearerToken('Bearer   xyz')).toBe('xyz');
+  });
+
+  it('returns null when the header is missing or malformed', () => {
+    expect(extractBearerToken(null)).toBeNull();
+    expect(extractBearerToken(undefined)).toBeNull();
+    expect(extractBearerToken('')).toBeNull();
+    expect(extractBearerToken('Basic abc')).toBeNull();
+    expect(extractBearerToken('Bearer')).toBeNull(); // no token
+    expect(extractBearerToken('Bearer ')).toBeNull(); // empty token
+  });
+});
+
+describe('internalKeyMatches', () => {
+  it('matches when both strings are equal and non-empty', () => {
+    expect(internalKeyMatches('abc', 'abc')).toBe(true);
+  });
+
+  it('rejects mismatches, empty strings, or null', () => {
+    expect(internalKeyMatches('abc', 'abd')).toBe(false);
+    expect(internalKeyMatches('abc', '')).toBe(false);
+    expect(internalKeyMatches('', 'abc')).toBe(false);
+    expect(internalKeyMatches(null, 'abc')).toBe(false);
+    expect(internalKeyMatches('abc', null)).toBe(false);
+    expect(internalKeyMatches('abc', undefined)).toBe(false);
+  });
+
+  it('rejects when lengths differ even if prefix matches', () => {
+    expect(internalKeyMatches('abc', 'abcd')).toBe(false);
+    expect(internalKeyMatches('abcd', 'abc')).toBe(false);
+  });
+});
+
+describe('hasValidInternalKey', () => {
+  it('accepts a valid Bearer header with matching key', () => {
+    expect(hasValidInternalKey('Bearer test-key-2026', 'test-key-2026')).toBe(true);
+  });
+
+  it('rejects all the not-valid cases', () => {
+    expect(hasValidInternalKey('Bearer wrong', 'test-key-2026')).toBe(false);
+    expect(hasValidInternalKey(null, 'test-key-2026')).toBe(false);
+    expect(hasValidInternalKey('Bearer test', undefined)).toBe(false);
+    expect(hasValidInternalKey('Basic test', 'test')).toBe(false);
+  });
+});

--- a/apps/superadmin/lib/middleware/api-auth-matcher.ts
+++ b/apps/superadmin/lib/middleware/api-auth-matcher.ts
@@ -1,0 +1,85 @@
+// Defense-in-depth helper for the middleware-level /api/* auth gate.
+// The route-level `requireSuperadmin` / `requireSuperadminOrInternal` helpers
+// are still the authoritative check — this just prevents any future route
+// from accidentally going live without auth. Issue #34 PR F.
+
+/**
+ * Paths under /api/* that MUST be reachable without a session cookie and
+ * without an INTERNAL_API_KEY. Each entry is matched as a path prefix (a
+ * trailing slash means "this directory and everything under it"); entries
+ * without a trailing slash match the exact path only.
+ *
+ * Keep this list minimal — every entry is a hole in the middleware gate.
+ */
+export const PUBLIC_API_PATHS: ReadonlyArray<{
+  prefix: string;
+  reason: 'oauth' | 'hmac' | 'health';
+  exact?: boolean;
+}> = [
+  // OAuth callbacks (Google etc.) — user identity is established by the
+  // provider's redirect, not by a pre-existing session.
+  { prefix: '/api/auth/', reason: 'oauth' },
+  // HMAC-signed webhooks — verified at the route level against a shared
+  // secret rather than a user session.
+  { prefix: '/api/webhooks/', reason: 'hmac' },
+  // People-DB OCR callback is HMAC-signed with `x-ocr-signature` instead of
+  // living under /api/webhooks/, so it needs its own exception.
+  {
+    prefix: '/api/people-db/ingest/ocr/callback',
+    reason: 'hmac',
+    exact: true,
+  },
+];
+
+/** True when `pathname` is in the public API allow-list. */
+export function isPublicApiPath(pathname: string): boolean {
+  for (const entry of PUBLIC_API_PATHS) {
+    if (entry.exact) {
+      if (pathname === entry.prefix) return true;
+    } else if (pathname.startsWith(entry.prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Read the bearer token from the Authorization header. Returns null when the
+ * header is absent or doesn't match the `Bearer <token>` shape.
+ */
+export function extractBearerToken(
+  headerValue: string | null | undefined,
+): string | null {
+  if (!headerValue) return null;
+  const match = headerValue.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+  const token = match[1].trim();
+  return token.length > 0 ? token : null;
+}
+
+/**
+ * Compare the presented bearer token with the expected INTERNAL_API_KEY.
+ *
+ * NOTE: middleware runs on the edge runtime where `node:crypto.timingSafeEqual`
+ * is not available. This is the *first* of two checks — the route-level
+ * `requireSuperadminOrInternal` does the canonical constant-time comparison.
+ * A middleware bypass here doesn't grant access by itself; it only defers
+ * auth enforcement to the route handler, which runs on the node runtime.
+ */
+export function internalKeyMatches(
+  presented: string | null,
+  expected: string | null | undefined,
+): boolean {
+  if (!presented || !expected) return false;
+  if (presented.length !== expected.length) return false;
+  return presented === expected;
+}
+
+/** True when the caller has a valid INTERNAL_API_KEY bearer token. */
+export function hasValidInternalKey(
+  authorizationHeader: string | null | undefined,
+  expectedKey: string | null | undefined,
+): boolean {
+  const token = extractBearerToken(authorizationHeader);
+  return internalKeyMatches(token, expectedKey);
+}

--- a/apps/superadmin/middleware.ts
+++ b/apps/superadmin/middleware.ts
@@ -3,6 +3,15 @@ import { createClient } from '@supabase/supabase-js';
 import { NextResponse, type NextRequest } from 'next/server';
 
 import { createSupabaseRedirectCookieBridge } from '@/lib/middleware/supabase-redirect-cookies';
+import {
+  hasValidInternalKey,
+  isPublicApiPath,
+} from '@/lib/middleware/api-auth-matcher';
+
+/** JSON 401/403 body shape for API callers (Issue #34 PR F). */
+function jsonAuthError(status: 401 | 403, message: string): NextResponse {
+  return NextResponse.json({ error: message }, { status });
+}
 
 /** 從 request 取得客戶端 IP（支援 proxy 的 x-forwarded-for / x-real-ip） */
 function getClientIp(request: NextRequest): string {
@@ -20,6 +29,22 @@ export async function middleware(request: NextRequest) {
   }
 
   const isSuperadminRoute = request.nextUrl.pathname.startsWith('/superadmin');
+  const isApiRoute =
+    request.nextUrl.pathname.startsWith('/api/') &&
+    !isPublicApiPath(request.nextUrl.pathname);
+
+  // ── /api/* defense-in-depth fast path (Issue #34 PR F) ──────────────────
+  // Server-to-server callers (skills, scheduled-tasks MCP, internal cron)
+  // present `Authorization: Bearer <INTERNAL_API_KEY>`. Let them through
+  // here so the route-level `requireSuperadminOrInternal` can do the
+  // authoritative constant-time key check on the node runtime.
+  if (isApiRoute) {
+    const authHeader = request.headers.get('authorization');
+    const internalKey = process.env.INTERNAL_API_KEY;
+    if (hasValidInternalKey(authHeader, internalKey)) {
+      return NextResponse.next({ request });
+    }
+  }
 
   // IP 白名單 + 黑名單檢查：superadmin 路由先檢查 IP / User-Agent
   // 白名單非空時：不在白名單內的 IP 直接拒絕（優先）
@@ -99,16 +124,23 @@ export async function middleware(request: NextRequest) {
     return redirectResponse;
   };
 
-  // 1. 未登入：重導向至本機登入頁（同 port 3001），避免依賴 3000 主站
-  if (isSuperadminRoute && !user) {
-    const loginUrl = new URL('/login', request.url);
-    const returnUrl = request.nextUrl.pathname + request.nextUrl.search;
-    if (returnUrl && returnUrl !== '/login') loginUrl.searchParams.set('returnUrl', returnUrl);
-    return redirectWithCookies(loginUrl);
+  // 1. 未登入
+  if (!user) {
+    // API callers get JSON 401 — they can't follow a redirect to /login.
+    if (isApiRoute) {
+      return jsonAuthError(401, 'Unauthorized: missing or invalid session');
+    }
+    // Superadmin UI callers redirect to login with returnUrl preserved.
+    if (isSuperadminRoute) {
+      const loginUrl = new URL('/login', request.url);
+      const returnUrl = request.nextUrl.pathname + request.nextUrl.search;
+      if (returnUrl && returnUrl !== '/login') loginUrl.searchParams.set('returnUrl', returnUrl);
+      return redirectWithCookies(loginUrl);
+    }
   }
 
   // 2. 已登入：以 IAM 為準判斷是否為 Super Admin（與主站 Portal 一致）
-  if (isSuperadminRoute && user) {
+  if ((isSuperadminRoute || isApiRoute) && user) {
     const { data: roleRows } = await supabase.rpc('get_user_roles', {
       lookup_user_id: user.id,
     });
@@ -119,6 +151,9 @@ export async function middleware(request: NextRequest) {
       roles.includes('super_admin') ||
       user.user_metadata?.role === 'super_admin';
     if (!isSuperAdmin) {
+      if (isApiRoute) {
+        return jsonAuthError(403, 'Forbidden: super_admin role required');
+      }
       const loginUrl = new URL('/login', request.url);
       loginUrl.searchParams.set('reason', 'insufficient_role');
       return redirectWithCookies(loginUrl);
@@ -129,5 +164,17 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/docs', '/superadmin/:path*'],
+  matcher: [
+    '/docs',
+    '/superadmin/:path*',
+    // /api/* defense-in-depth (Issue #34 PR F). Negative lookahead excludes
+    // the three public-path families handled explicitly by their routes:
+    //   - /api/auth/         — OAuth callbacks
+    //   - /api/webhooks/     — HMAC-signed inbound webhooks
+    //   - /api/people-db/ingest/ocr/callback — HMAC OCR callback
+    // Keep this regex and PUBLIC_API_PATHS in lib/middleware/api-auth-matcher
+    // in sync — the lib list is the source of truth for documentation but the
+    // matcher needs the regex form for Next.js.
+    '/api/((?!auth/|webhooks/|people-db/ingest/ocr/callback$).+)',
+  ],
 };


### PR DESCRIPTION
Follow-up to merged PRs #35–#37 (A/B/C). [#34](https://github.com/jason660519/Owner-Property-Management-AI-SPA/issues/34) Phase 6.

PRs A–E 加了 route-level guard 到 ~60 支 admin-client route。本 PR 加第二層：superadmin middleware 在 route handler 執行**之前**就擋下未認證 /api/* 流量。

兩個 failure mode 是 route-level 單獨無法接住的：
1. **未來 route 忘了加 guard** —— middleware 仍 401/403，新 route 漏寫 `requireSuperadmin(...)` 會在 dev 顯眼失敗而非靜默可利用
2. **Phase 1 audit 漏掉的 route** —— 凡 /api 下未在 allow-list 裡的都被擋

## 變更

### 新：`apps/superadmin/lib/middleware/api-auth-matcher.ts`
- `PUBLIC_API_PATHS` allow-list（3 entries，每個標 reason）：
  - `/api/auth/` (oauth)
  - `/api/webhooks/` (hmac)
  - `/api/people-db/ingest/ocr/callback` exact (hmac)
- `isPublicApiPath(pathname)` — prefix / exact-match lookup
- `extractBearerToken(header)` — `Bearer <token>` parser
- `internalKeyMatches(presented, expected)` — 等長字串比較（edge runtime 無 `timingSafeEqual`，route-level `requireSuperadminOrInternal` 做常時比較 as second layer）
- `hasValidInternalKey(authHeader, expectedKey)` — 方便方法

### 改：`apps/superadmin/middleware.ts`
- Matcher 擴到 `/api/((?!auth/|webhooks/|people-db/ingest/ocr/callback$).+)`
- 在 Supabase check 前先查 bearer token：若 `Authorization: Bearer $INTERNAL_API_KEY` valid → `NextResponse.next()`，讓 server-to-server caller（skills、scheduled-tasks MCP、cron forwarding）通過到 route handler，由 node runtime 的 `requireSuperadminOrInternal` 做常時比較
- API caller 未認證時回 JSON 401/403（不 redirect 到 `/login`），client 不會誤以為 HTML 登入頁是 API response

### 新：13 unit tests（`lib/middleware/__tests__/api-auth-matcher.test.ts`）
涵蓋 allow-list shape、path 匹配（含反面：`/api/people-db/ingest/ocr/callback/foo` 不 leak）、bearer 解析、constant-length compare、end-to-end。

## Defense-in-depth 互動

- Session-UI caller 仍被 route-level `requireSuperadmin` guard；middleware 未認證時先被擋
- Internal-key caller（PR C/G 的 routes）透過 bearer fast path 通過 middleware，route-level 做常時比較
- OAuth / webhook routes 在 allow-list，由各自的 provider redirect / HMAC 驗證保護，不變

## 驗證

- jest（新 matcher suite）: 13 / 13 pass
- jest（全 workspace）: 1408 pass / 2 skipped；12 failures 與 A/B/C/D/E pre-existing 相同
- `tsc --noEmit`: 0 errors
- `next build`: Compiled successfully in 26.7s

🤖 Generated with [Claude Code](https://claude.com/claude-code)