### PR TITLE
fix(superadmin): dual-track dev-tasks local-agent endpoints + update tools (#34 PR G)

### DIFF
--- a/apps/superadmin/app/api/dev-tasks/[id]/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/dev-tasks/[id]/__tests__/route.test.ts
@@ -1,0 +1,146 @@
+// Issue #34 PR G — /api/dev-tasks/[id] PATCH + POST are dual-track:
+// superadmin session OR INTERNAL_API_KEY bearer (called by local-agent
+// tooling at tools/local-agent/dev-tasks-agent.ts).
+//
+// GET handler migration to session-only is tracked in PR D (separate PR),
+// so this test file does not cover GET.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  source?: 'session' | 'internal';
+  userId?: string | null;
+}
+const authState: AuthState = { ok: true, source: 'session', userId: 'admin-1' };
+
+jest.mock('@/lib/auth/require-superadmin-or-internal', () => ({
+  requireSuperadminOrInternal: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, source: authState.source ?? 'session', userId: authState.userId ?? null };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+// The GET handler still reads the legacy x-user-id / resolveUserId pair on
+// this branch (PR G's sibling PR D migrates it). Mock resolveUserId so the
+// GET default import does not blow up when the module evaluates.
+jest.mock('@/lib/resolve-ai-settings-user', () => ({
+  resolveUserId: jest.fn(async (_admin: unknown, uid: string) => uid),
+}));
+
+const fromSpy = jest.fn();
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      const maybeSingle = () => Promise.resolve({ data: { logs: ['old log'] }, error: null });
+      const update = () => ({ eq: () => Promise.resolve({ error: null }) });
+      return {
+        select: () => ({ eq: () => ({ maybeSingle }) }),
+        update,
+      };
+    },
+  }),
+}));
+
+import { PATCH, POST } from '../route';
+
+function patchReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/dev-tasks/task-1', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+function postReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/dev-tasks/task-1', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  authState.source = 'session';
+  authState.userId = 'admin-1';
+});
+
+describe('PATCH /api/dev-tasks/[id]', () => {
+  it('returns 401 when neither session nor internal key is valid', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await PATCH(patchReq({ logs: ['new log'] }), {
+      params: Promise.resolve({ id: 'task-1' }),
+    });
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts internal-key caller (local-agent path)', async () => {
+    authState.source = 'internal';
+    authState.userId = null;
+    const res = await PATCH(patchReq({ logs: ['new log'] }), {
+      params: Promise.resolve({ id: 'task-1' }),
+    });
+    expect(res.status).toBe(200);
+    expect(fromSpy).toHaveBeenCalledWith('dev_tasks');
+  });
+
+  it('accepts session caller', async () => {
+    const res = await PATCH(patchReq({ logs: ['new log'] }), {
+      params: Promise.resolve({ id: 'task-1' }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 when logs array is missing (after auth)', async () => {
+    const res = await PATCH(patchReq({}), {
+      params: Promise.resolve({ id: 'task-1' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/dev-tasks/[id]', () => {
+  it('returns 401 when neither session nor internal key is valid', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await POST(postReq({ status: 'succeeded' }), {
+      params: Promise.resolve({ id: 'task-1' }),
+    });
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts internal-key caller and marks the task complete', async () => {
+    authState.source = 'internal';
+    authState.userId = null;
+    const res = await POST(
+      postReq({ status: 'succeeded', resultSummary: { ok: true } }),
+      { params: Promise.resolve({ id: 'task-1' }) },
+    );
+    expect(res.status).toBe(200);
+    expect(fromSpy).toHaveBeenCalledWith('dev_tasks');
+  });
+
+  it('accepts session caller', async () => {
+    const res = await POST(postReq({ status: 'failed' }), {
+      params: Promise.resolve({ id: 'task-1' }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 for invalid status value (after auth)', async () => {
+    const res = await POST(postReq({ status: 'bogus' }), {
+      params: Promise.resolve({ id: 'task-1' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/superadmin/app/api/dev-tasks/[id]/route.ts
+++ b/apps/superadmin/app/api/dev-tasks/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
 import { resolveUserId } from '@/lib/resolve-ai-settings-user';
+import { requireSuperadminOrInternal } from '@/lib/auth/require-superadmin-or-internal';
 
 type DevTaskStatus = 'queued' | 'running' | 'succeeded' | 'failed';
 
@@ -54,10 +55,19 @@ export async function GET(
 }
 
 // Local agents can append logs for a task.
+// Dual-track auth: superadmin session OR INTERNAL_API_KEY (Issue #34 PR G).
 export async function PATCH(
   request: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/dev-tasks/[id]',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   try {
     const supabase = createAdminClient();
     const { id: taskId } = await context.params;
@@ -108,10 +118,19 @@ export async function PATCH(
 }
 
 // Local agents mark task complete with final status and summary.
+// Dual-track auth: superadmin session OR INTERNAL_API_KEY (Issue #34 PR G).
 export async function POST(
   request: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/dev-tasks/[id]',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   try {
     const supabase = createAdminClient();
     const { id: taskId } = await context.params;

--- a/apps/superadmin/app/api/dev-tasks/next/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/dev-tasks/next/__tests__/route.test.ts
@@ -1,0 +1,117 @@
+// Issue #34 PR G — /api/dev-tasks/next (GET) is dual-track: superadmin
+// session OR INTERNAL_API_KEY bearer. Primary caller is the local-agent
+// polling loop at tools/local-agent/dev-tasks-agent.ts.
+
+import { NextRequest } from 'next/server';
+
+interface AuthState {
+  ok: boolean;
+  status?: 401 | 403;
+  source?: 'session' | 'internal';
+  userId?: string | null;
+}
+const authState: AuthState = { ok: true, source: 'internal', userId: null };
+
+jest.mock('@/lib/auth/require-superadmin-or-internal', () => ({
+  requireSuperadminOrInternal: jest.fn(async () => {
+    if (authState.ok) {
+      return { ok: true, source: authState.source ?? 'internal', userId: authState.userId ?? null };
+    }
+    return { ok: false, status: authState.status ?? 401, message: 'denied' };
+  }),
+}));
+
+const fromSpy = jest.fn();
+
+const nextTask: { data: unknown; error: null | { message: string } } = {
+  data: {
+    id: 'task-1',
+    user_id: 'u1',
+    row_id: 'R01',
+    feature_name: 'feat',
+    ide: 'Cursor',
+    prompt: 'hi',
+    metadata: {},
+    status: 'queued',
+  },
+  error: null,
+};
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      fromSpy(table);
+      const maybeSingle = () => Promise.resolve(nextTask);
+      const limit = () => ({ maybeSingle });
+      const order = () => ({ limit });
+      const select = () => ({ eq: () => ({ eq: () => ({ order }) }) });
+      const update = () => ({ eq: () => Promise.resolve({ error: null }) });
+      return { select, update };
+    },
+  }),
+}));
+
+import { GET } from '../route';
+
+function req(ide: string | null = 'Cursor'): NextRequest {
+  const base = 'http://localhost:3001/api/dev-tasks/next';
+  const url = ide ? `${base}?ideType=${encodeURIComponent(ide)}` : base;
+  return new NextRequest(url, { method: 'GET' });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authState.ok = true;
+  authState.status = undefined;
+  authState.source = 'internal';
+  authState.userId = null;
+  nextTask.data = {
+    id: 'task-1',
+    user_id: 'u1',
+    row_id: 'R01',
+    feature_name: 'feat',
+    ide: 'Cursor',
+    prompt: 'hi',
+    metadata: {},
+    status: 'queued',
+  };
+  nextTask.error = null;
+});
+
+describe('GET /api/dev-tasks/next', () => {
+  it('returns 401 when auth fails (no session, no valid key)', async () => {
+    authState.ok = false;
+    authState.status = 401;
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when session lacks super_admin role', async () => {
+    authState.ok = false;
+    authState.status = 403;
+    const res = await GET(req());
+    expect(res.status).toBe(403);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 via internal key (local-agent polling)', async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.task?.id).toBe('task-1');
+    expect(fromSpy).toHaveBeenCalledWith('dev_tasks');
+  });
+
+  it('returns 200 via session (manual UI trigger)', async () => {
+    authState.source = 'session';
+    authState.userId = 'admin-1';
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 when ideType missing (after auth)', async () => {
+    const res = await GET(req(null));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/superadmin/app/api/dev-tasks/next/route.ts
+++ b/apps/superadmin/app/api/dev-tasks/next/route.ts
@@ -1,9 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/utils/supabase/admin';
+import { requireSuperadminOrInternal } from '@/lib/auth/require-superadmin-or-internal';
 
 type IDEType = 'Cursor' | 'VSCode' | 'Antigravity' | 'Claude CLI' | 'TRAE';
 
+// Local agents poll this endpoint to claim the next queued dev task.
+// Dual-track auth: superadmin session OR INTERNAL_API_KEY (Issue #34 PR G).
 export async function GET(request: NextRequest) {
+  const authResult = await requireSuperadminOrInternal({
+    request,
+    routeLabel: 'api/dev-tasks/next',
+  });
+  if (!authResult.ok) {
+    return NextResponse.json({ error: authResult.message }, { status: authResult.status });
+  }
+
   try {
     const supabase = createAdminClient();
 

--- a/apps/superadmin/app/api/paperclip/cron/run/__tests__/route.test.ts
+++ b/apps/superadmin/app/api/paperclip/cron/run/__tests__/route.test.ts
@@ -74,8 +74,8 @@ describe('POST /api/paperclip/cron/run', () => {
     const res = await POST(postReq({ job_type: 'agent_health' }));
     expect(res.status).toBe(200);
     expect(fetchSpy).toHaveBeenCalled();
-    const fetchCall = fetchSpy.mock.calls[0];
-    const init = fetchCall[1] as { headers?: Record<string, string> };
+    const fetchCall = fetchSpy.mock.calls[0] as unknown as [string, { headers?: Record<string, string> }];
+    const init = fetchCall[1];
     expect(init?.headers?.Authorization).toBe('Bearer test-key');
   });
 

--- a/scripts/complete-dev-task.sh
+++ b/scripts/complete-dev-task.sh
@@ -13,8 +13,14 @@ if [[ "$STATUS" != "succeeded" && "$STATUS" != "failed" ]]; then
   exit 1
 fi
 
+# Issue #34 PR G: /api/dev-tasks/[id] POST is gated behind INTERNAL_API_KEY
+# bearer. Load via tools/paperclip/auth-header.sh (reads env or .env.local).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AUTH_HEADER="$(bash "$REPO_ROOT/tools/paperclip/auth-header.sh")"
+
 echo "Marking task $TASK_ID as $STATUS (POST $BASE_URL/api/dev-tasks/$TASK_ID)"
 curl -s -X POST "$BASE_URL/api/dev-tasks/$TASK_ID" \
+  -H "$AUTH_HEADER" \
   -H "Content-Type: application/json" \
   -d "{\"status\":\"$STATUS\",\"resultSummary\":{\"message\":\"Marked complete via scripts/complete-dev-task.sh\",\"completedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}"
 echo ""

--- a/tools/local-agent/dev-tasks-agent.ts
+++ b/tools/local-agent/dev-tasks-agent.ts
@@ -361,11 +361,24 @@ const ADAPTERS: IDEAdapter[] = [
 
 // --- HTTP helpers ---
 
+/**
+ * Authorization headers sent on every superadmin API call. Issue #34 PR G
+ * gated /api/dev-tasks/next, PATCH /api/dev-tasks/[id], and POST
+ * /api/dev-tasks/[id] behind `requireSuperadminOrInternal`, so the local
+ * agent must present `Authorization: Bearer $INTERNAL_API_KEY` to reach them.
+ * The key is loaded from env (exported by run-cursor.sh / run-claude.sh)
+ * — if missing, calls will 401 with a helpful hint from the route handler.
+ */
+function authHeaders(): Record<string, string> {
+  const key = process.env.INTERNAL_API_KEY ?? '';
+  return key ? { Authorization: `Bearer ${key}` } : {};
+}
+
 async function fetchNextTask(baseUrl: string, ide: IDEType, agentId: string): Promise<DevTask | null> {
   const url = new URL('/api/dev-tasks/next', baseUrl);
   url.searchParams.set('ideType', ide);
   url.searchParams.set('agentId', agentId);
-  const res = await fetch(url.toString());
+  const res = await fetch(url.toString(), { headers: authHeaders() });
   if (!res.ok) { console.error('[LocalAgent] fetchNextTask error:', res.status); return null; }
   return ((await res.json()) as NextTaskResponse).task ?? null;
 }
@@ -373,7 +386,7 @@ async function fetchNextTask(baseUrl: string, ide: IDEType, agentId: string): Pr
 async function appendLogs(baseUrl: string, taskId: string, logs: string[]): Promise<void> {
   const res = await fetch(new URL(`/api/dev-tasks/${taskId}`, baseUrl).toString(), {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify({ logs }),
   });
   if (!res.ok) console.error('[LocalAgent] appendLogs error:', res.status, await res.text());
@@ -384,7 +397,7 @@ async function completeTask(
 ): Promise<void> {
   const res = await fetch(new URL(`/api/dev-tasks/${taskId}`, baseUrl).toString(), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify({ status, resultSummary }),
   });
   if (!res.ok) console.error('[LocalAgent] completeTask error:', res.status, await res.text());


### PR DESCRIPTION
Follow-up to merged PR #37 (PR C). [#34](https://github.com/jason660519/Owner-Property-Management-AI-SPA/issues/34) Phase 7。

## 背景

PR D 把 UI-facing 的 `GET /api/dev-tasks/[id]` 和 `/api/dev-tasks` POST/GET guard 成 session-only，但同檔另外 3 個 handler 是被 `tools/local-agent/dev-tasks-agent.ts` 呼叫的 —— 無 session cookie 可帶，故留給 PR G 用 dual-track（session OR INTERNAL_API_KEY）。

## Routes migrated (3 handlers)

全改用 PR C 引入的 `requireSuperadminOrInternal`：

- **PATCH `/api/dev-tasks/[id]`** — local agent 執行時 append logs
- **POST `/api/dev-tasks/[id]`** — local agent 標記 task 完成
- **GET `/api/dev-tasks/next`** — local agent polling 領下個 queued task

## Caller 更新

### `tools/local-agent/dev-tasks-agent.ts`
新 `authHeaders()` helper 讀 `process.env.INTERNAL_API_KEY`，附加 `Authorization: Bearer` 到：
- `fetchNextTask` (GET)
- `appendLogs` (PATCH)
- `completeTask` (POST)

若 env var 未設定，請求會 401 帶清楚的 "missing session or header identity" 訊息。

### `scripts/complete-dev-task.sh`
Source `tools/paperclip/auth-header.sh` 拿 `Authorization: Bearer <key>`，跟 PR C 為 `/dispatch-agents` / `/review-agent-work` skill 建的同 pattern。

## 開發者一次性設定（若 PR C 已做過就不必再做）

```bash
# apps/superadmin/.env.local  (gitignored)
INTERNAL_API_KEY=\$(openssl rand -hex 32)
```

## 附帶修正：PR C 測試 tsc error

`apps/superadmin/app/api/paperclip/cron/run/__tests__/route.test.ts` 在 PR G 的 tsc pass 下觸發 `Tuple type '[]' of length '0' has no element at index '1'`。修法是把 `jest.Mock` 的 call-array narrow 改成 `unknown as [...]` cast —— 純 tsc fix，runtime 行為不變。

## 測試（2 新檔、13 cases）

- `dev-tasks/[id]/__tests__/route.test.ts`: 8 cases（PATCH + POST 各 4：401 / internal-key / session / 400-edge）
- `dev-tasks/next/__tests__/route.test.ts`: 5 cases（401 / 403 / internal-key / session / 400-missing-ideType）

## 驗證

- jest（PR G + 修正的 PR C suite）: 17 / 17 pass
- `tsc --noEmit`: 0 errors
- `next build`: Compiled successfully in 35.5s

## Branch base

原本 stacked on `fix/api-auth-audit-pr-c`（PR #37 已 merge，base 自動回到 main）。Diff 只顯示 PR G 的 7 個檔改動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)