### PR TITLE
feat(superadmin): force dataset_root on people-db import (Row 146 Step 3)

### DIFF
--- a/apps/superadmin/app/api/people-db/import/jobs/__tests__/dataset-root-required.test.ts
+++ b/apps/superadmin/app/api/people-db/import/jobs/__tests__/dataset-root-required.test.ts
@@ -1,0 +1,74 @@
+// Row 146 Step 3 — verify the asynchronous /import/jobs route enforces
+// dataset_root and returns 400 with a clear message when callers omit it.
+
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: async () => ({
+    ok: true,
+    userId: 'admin-1',
+    source: 'session' as const,
+    viaSession: true,
+  }),
+}));
+
+jest.mock('@/lib/people-db/import-jobs', () => ({
+  enqueueImportJob: jest.fn().mockResolvedValue({
+    id: 'job-1',
+    status: 'pending',
+    file_name: 'sample.csv',
+    file_size_bytes: 11,
+    created_at: '2026-04-19T00:00:00Z',
+  }),
+}));
+
+jest.mock('@/utils/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      select: () => ({
+        order: () => ({ limit: async () => ({ data: [], error: null }) }),
+      }),
+    }),
+  }),
+}));
+
+import { POST } from '../route';
+
+function makeRequest(form: FormData) {
+  // See submit/__tests__/dataset-root-required.test.ts for why we stub formData().
+  const req = new NextRequest('http://localhost:3001/api/people-db/import/jobs', {
+    method: 'POST',
+  });
+  Object.defineProperty(req, 'formData', { value: async () => form });
+  return req;
+}
+
+function buildForm(extra: Partial<{ dataset_root: string }> = {}) {
+  const form = new FormData();
+  form.append('file', new File(['name\nAlice'], 'sample.csv', { type: 'text/csv' }));
+  form.append('column_mapping', JSON.stringify({ full_name: 0 }));
+  if (extra.dataset_root !== undefined) form.append('dataset_root', extra.dataset_root);
+  return form;
+}
+
+describe('POST /api/people-db/import/jobs — Row 146 dataset_root enforcement', () => {
+  it('returns 400 when dataset_root is missing', async () => {
+    const res = await POST(makeRequest(buildForm()));
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { detail?: string };
+    expect(json.detail).toMatch(/dataset_root is required/);
+    expect(json.detail).toMatch(/Row 146/);
+  });
+
+  it('returns 400 when dataset_root is empty string', async () => {
+    const res = await POST(makeRequest(buildForm({ dataset_root: '' })));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 202 when dataset_root is provided', async () => {
+    const res = await POST(makeRequest(buildForm({ dataset_root: '2026Q1 北市新檔' })));
+    expect(res.status).toBe(202);
+    const json = (await res.json()) as { job_id?: string };
+    expect(json.job_id).toBe('job-1');
+  });
+});

--- a/apps/superadmin/app/api/people-db/import/jobs/route.ts
+++ b/apps/superadmin/app/api/people-db/import/jobs/route.ts
@@ -84,14 +84,19 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const datasetRoot = stringField(form, 'dataset_root') || null;
+  // Row 146: dataset_root is mandatory; see submit/route.ts for rationale.
+  const datasetRoot = stringField(form, 'dataset_root');
+  if (!datasetRoot) {
+    return NextResponse.json(
+      { detail: 'dataset_root is required (Row 146: 匯入時必須指定資料集根目錄)' },
+      { status: 400 },
+    );
+  }
   const datasetSubpath = stringField(form, 'dataset_subpath') || null;
   const explicitPath = stringField(form, 'dataset_path');
   const datasetPath =
     explicitPath ||
-    [datasetRoot, datasetSubpath].filter(Boolean).join('/') ||
-    stringField(form, 'data_source') ||
-    'uncategorized';
+    [datasetRoot, datasetSubpath].filter(Boolean).join('/');
 
   try {
     const job = await enqueueImportJob({

--- a/apps/superadmin/app/api/people-db/import/submit/__tests__/dataset-root-required.test.ts
+++ b/apps/superadmin/app/api/people-db/import/submit/__tests__/dataset-root-required.test.ts
@@ -1,0 +1,71 @@
+// Row 146 Step 3 — verify the synchronous /import/submit route enforces
+// dataset_root and returns a 400 with a clear message when callers omit it.
+
+import { NextRequest } from 'next/server';
+
+// Auth: pass through as a super_admin so the route reaches the validation logic.
+jest.mock('@/lib/auth/require-superadmin', () => ({
+  requireSuperadmin: async () => ({
+    ok: true,
+    userId: 'admin-1',
+    source: 'session' as const,
+    viaSession: true,
+  }),
+}));
+
+// Stub the heavy file-parser + ES indexer; they should never be invoked when
+// validation fails, but we still mock so a regression that bypasses the guard
+// doesn't try to hit a real ES instance during tests.
+jest.mock('@/lib/people-db/parse-dispatch', () => ({
+  dispatchParse: jest.fn(),
+  extOf: (name: string) => name.toLowerCase().slice(name.lastIndexOf('.')),
+  isSupportedExt: (ext: string) => ['.csv', '.txt', '.xlsx', '.pdf'].includes(ext),
+  UnsupportedFormatError: class extends Error {},
+}));
+jest.mock('@/lib/people-db/es-gateway', () => ({
+  esBulkIndex: jest.fn().mockResolvedValue({ indexed: 0, failed: 0, failures: [] }),
+}));
+jest.mock('@/lib/people-db/import-mapper', () => ({
+  mapRowsToDocuments: jest.fn(() => []),
+}));
+
+import { POST } from '../route';
+
+function makeRequest(form: FormData) {
+  // Build a NextRequest without a real multipart body — multipart FormData
+  // requires TransformStream which isn't polyfilled in our jest env. The
+  // route only reads via req.formData(), so we override that one method.
+  const req = new NextRequest('http://localhost:3001/api/people-db/import/submit', {
+    method: 'POST',
+  });
+  Object.defineProperty(req, 'formData', { value: async () => form });
+  return req;
+}
+
+function buildForm(extra: Partial<{ dataset_root: string }> = {}) {
+  const form = new FormData();
+  form.append('file', new File(['name\nAlice'], 'sample.csv', { type: 'text/csv' }));
+  form.append('column_mapping', JSON.stringify({ full_name: 0 }));
+  if (extra.dataset_root !== undefined) form.append('dataset_root', extra.dataset_root);
+  return form;
+}
+
+describe('POST /api/people-db/import/submit — Row 146 dataset_root enforcement', () => {
+  it('returns 400 when dataset_root is missing', async () => {
+    const res = await POST(makeRequest(buildForm()));
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { detail?: string };
+    expect(json.detail).toMatch(/dataset_root is required/);
+    expect(json.detail).toMatch(/Row 146/);
+  });
+
+  it('returns 400 when dataset_root is empty string', async () => {
+    const res = await POST(makeRequest(buildForm({ dataset_root: '' })));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when dataset_root is whitespace-only', async () => {
+    const res = await POST(makeRequest(buildForm({ dataset_root: '   ' })));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/superadmin/app/api/people-db/import/submit/route.ts
+++ b/apps/superadmin/app/api/people-db/import/submit/route.ts
@@ -80,14 +80,22 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // Row 146: dataset_root is now mandatory so every imported record can be
+  // traced back to a named dataset. The legacy data_source / 'uncategorized'
+  // fallbacks are intentionally removed — callers that hit this 400 should
+  // surface the dataset picker on the client (see ImportWorkspace).
   const datasetRoot = stringField(form, 'dataset_root');
+  if (!datasetRoot) {
+    return NextResponse.json(
+      { detail: 'dataset_root is required (Row 146: 匯入時必須指定資料集根目錄)' },
+      { status: 400 },
+    );
+  }
   const datasetSubpath = stringField(form, 'dataset_subpath');
   const explicitPath = stringField(form, 'dataset_path');
   const datasetPath =
     explicitPath ||
-    [datasetRoot, datasetSubpath].filter(Boolean).join('/') ||
-    stringField(form, 'data_source') ||
-    'uncategorized';
+    [datasetRoot, datasetSubpath].filter(Boolean).join('/');
 
   const batchId = randomUUID();
 

--- a/apps/superadmin/app/data/roadmap.ts
+++ b/apps/superadmin/app/data/roadmap.ts
@@ -2640,7 +2640,7 @@ const RAW_FEATURES: RoadmapFeature[] = [
   {
     name: "超級管理員-尋人資料庫：5-tab 工作區整合 + 強制 dataset + Scope 顏色標記（ID 146）",
     locatedPage: "superadmin/settings/people-database",
-    percentage: 5,
+    percentage: 75,
     category: "超級管理員 (Super Admin)",
     points: 8,
     phase: "development",
@@ -2654,9 +2654,9 @@ const RAW_FEATURES: RoadmapFeature[] = [
       "/project-process/dev-logs/dev-people-db-workspace-consolidation-2026-04-19.md",
     testScriptPath: "apps/superadmin/unit_test/146",
     developmentProgress:
-      "2026/04/19（規劃 + Step 1 啟動 — Claude Sonnet 4.5）\n- 與 Jason 對齊四項決議：單頁 5-tab、Tools hub 保留並移除 people-db 卡片、Sidebar 合併、強制 dataset、預設 scope=全部 + 顏色標記\n- 探勘 4 個既有頁面：merge-candidates 已 export MergeCandidatesWorkspace、ingest 已 export IngestDashboardWorkspace、import 已 export PeopleDatabaseImportWorkspace、search 已 export PeopleDatabaseSearchWorkspace；只有 sources 尚未抽出 workspace\n- 確認 dataset 機制 DB 層已完整（dataset_path / dataset-tree API / sources 頁的 favorite/enable/notes），本 row 只動 UI 層 + 強制必填 + 顏色 util，不改 schema\n- 拆 4 commits：Step 1 重構 / Step 2 hub+sidebar / Step 3 強制 dataset / Step 4 scope+顏色，每個 commit 可獨立 deploy + rollback\n- dev-log: /project-process/dev-logs/dev-people-db-workspace-consolidation-2026-04-19.md",
+      "2026/04/19（規劃 + Step 1+2+3 完成 — Claude Sonnet 4.5）\n- 與 Jason 對齊四項決議：單頁 5-tab、Tools hub 保留並移除 people-db 卡片、Sidebar 合併、強制 dataset、預設 scope=全部 + 顏色標記\n- 探勘 4 個既有頁面：merge-candidates / ingest / import / search 都已 export workspace，sources 尚未抽出\n- 確認 dataset 機制 DB 層已完整（dataset_path / dataset-tree API / sources 頁的 favorite/enable/notes），本 row 只動 UI 層 + 強制必填 + 顏色 util，不改 schema\n- 拆 4 commits：Step 1+2 一個 PR / Step 3 一個 PR / Step 4 一個 PR\n\nStep 1 (5-tab 整合) ✅ — PR #42\n- /superadmin/settings/people-database 改為 5-tab dispatcher，?tab=xxx URL 同步\n- 5 個 workspace 用 next/dynamic({ssr:false}) lazy load，預設只 mount active tab\n- 從 sources/page.tsx 抽出 SourcesWorkspace；舊 route 仍可用做向後相容\n- page.test.tsx rewrite 6 cases 全綠\n\nStep 2 (Sidebar + Tools hub 清理) ✅ — PR #42\n- nav-items.ts：3 個 people-db entries → 1 個（指向 ?tab=search），移除孤立 GitMerge import\n- tools/page.tsx：移除「尋人資料庫工具」卡片 + 孤立 Users import\n- tools/page.test.tsx 改寫斷言\n\nStep 3 (強制 dataset_root) ✅ — feature/row-146-step-3-force-dataset\n- API: submit + jobs 加 dataset_root 必填驗證，缺值回 400 with 'Row 146' 提示；移除 'uncategorized' fallback\n- UI: 加「沿用既有 / 新建」radio；existing 模式從 /api/people-db/dataset-tree 拉 top-level roots → <select>；new 模式維持文字輸入\n- 缺 dataset_root 時：input 紅框 + submit button disabled + 紅字 helper「必填 — 缺值時無法提交」\n- 自動 flip：roots 載入後若有資料自動切到 existing 模式；roots 為空時 existing radio disabled\n- 11 cases pass（API submit ×3 + API jobs ×3 + UI ×5）；全 people-db 測試 247/247 + tsc clean\n- dev-log: /project-process/dev-logs/dev-people-db-workspace-consolidation-2026-04-19.md",
     testProgress:
-      "規劃中：unit 預計 3 cases（tabs URL sync / import dataset required / dataset color hash）+ e2e 1 case（consolidated flow），完成 Step 1 後補測試骨架。",
+      "Step 1+2+3 共 19 cases pass：page.test.tsx ×6（tab dispatcher）+ tools/page.test.tsx ×2 + import/__tests__/dataset-root-required.test.tsx ×5（UI 必填）+ submit/__tests__/dataset-root-required.test.ts ×3（API 400）+ jobs/__tests__/dataset-root-required.test.ts ×3（API 400 + 202 happy path）。整個 people-db 套件 247/247 全綠。Step 4 + e2e 待後續 PR。",
     lastModifiedBy: "Claude Sonnet 4.5",
     lastModifiedDate: "2026/04/19",
   },

--- a/apps/superadmin/app/superadmin/settings/people-database/import/__tests__/dataset-root-required.test.tsx
+++ b/apps/superadmin/app/superadmin/settings/people-database/import/__tests__/dataset-root-required.test.tsx
@@ -1,0 +1,141 @@
+// Row 146 Step 3 — verify the import workspace blocks submission when
+// dataset_root is empty and surfaces the radio + dropdown for picking an
+// existing root vs creating a new one.
+//
+// The dataset_root UI is gated behind the "preview" status — that's by
+// design: the user uploads a file first, and the picker appears alongside
+// the column-mapping panel. To reach that state in tests we mock both the
+// dataset-tree fetch and the import/preview fetch, then drive a file upload
+// through the hidden <input type="file"> the workspace renders at idle.
+
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PeopleDatabaseImportWorkspace } from '../page';
+
+// Strip DashboardLayout chrome.
+jest.mock('@/components/dashboard', () => ({
+  DashboardLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dashboard-layout">{children}</div>
+  ),
+}));
+
+// Mock URL.createObjectURL — jsdom doesn't implement it but lucide-react /
+// some upload UIs may call it on the synthetic File.
+beforeAll(() => {
+  if (typeof URL.createObjectURL === 'undefined') {
+    Object.defineProperty(URL, 'createObjectURL', { value: () => 'blob:mock' });
+  }
+});
+
+interface MockOptions {
+  roots?: string[];
+  previewColumns?: string[];
+}
+
+function setupFetchMocks({ roots = [], previewColumns = ['name'] }: MockOptions = {}) {
+  const fetchImpl = jest.fn().mockImplementation(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('/api/people-db/dataset-tree')) {
+      return {
+        ok: true,
+        json: async () => ({
+          tree: roots.map((label) => ({
+            label,
+            path: label,
+            count: 0,
+            children: [],
+          })),
+        }),
+      } as Response;
+    }
+    if (url.includes('/api/people-db/import/preview')) {
+      return {
+        ok: true,
+        json: async () => ({
+          columns: previewColumns.map((name, idx) => ({
+            index: idx,
+            name,
+            sample_values: ['Alice'],
+          })),
+          row_count: 1,
+          preview_rows: [{ name: 'Alice' }],
+        }),
+      } as Response;
+    }
+    return { ok: true, json: async () => ({}) } as Response;
+  });
+  global.fetch = fetchImpl as unknown as typeof fetch;
+  return fetchImpl;
+}
+
+async function renderAndUpload(opts: MockOptions = {}) {
+  const fetchImpl = setupFetchMocks(opts);
+  render(<PeopleDatabaseImportWorkspace />);
+
+  // Wait for dataset-tree fetch to settle.
+  await waitFor(() => {
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.stringContaining('/api/people-db/dataset-tree'),
+    );
+  });
+
+  // Trigger file upload to drive the workspace into the "preview" status.
+  const fileInput = document.getElementById('file-upload') as HTMLInputElement;
+  expect(fileInput).not.toBeNull();
+  const file = new File(['name\nAlice'], 'sample.csv', { type: 'text/csv' });
+  Object.defineProperty(fileInput, 'files', { value: [file], configurable: true });
+  fireEvent.change(fileInput);
+
+  // Wait for the metadata Card (which contains dataset_root) to mount.
+  await waitFor(() => {
+    expect(screen.getByTestId('dataset-root-field')).toBeInTheDocument();
+  });
+
+  return fetchImpl;
+}
+
+describe('PeopleDatabaseImportWorkspace (Row 146 — dataset_root required)', () => {
+  it('renders dataset_root with red asterisk + 必填 helper text', async () => {
+    await renderAndUpload();
+    const field = screen.getByTestId('dataset-root-field');
+    expect(field.querySelector('.text-red-500')).not.toBeNull();
+    expect(field.textContent).toMatch(/必填/);
+  });
+
+  it('falls back to "new" mode when no existing roots; existing radio disabled', async () => {
+    await renderAndUpload({ roots: [] });
+    const existingRadio = screen.getByLabelText(/沿用既有/, { selector: 'input' });
+    expect(existingRadio).toBeDisabled();
+    const newRadio = screen.getByLabelText(/新建資料集/, { selector: 'input' });
+    expect(newRadio).toBeChecked();
+    expect(screen.getByTestId('dataset-root-input')).toBeInTheDocument();
+  });
+
+  it('switches to "existing" mode automatically when roots exist', async () => {
+    await renderAndUpload({ roots: ['企業名錄', '北市稅籍', '台北市里長'] });
+    const select = screen.getByTestId('dataset-root-select') as HTMLSelectElement;
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      '',
+      '企業名錄',
+      '北市稅籍',
+      '台北市里長',
+    ]);
+  });
+
+  it('disables submit button when dataset_root is empty', async () => {
+    await renderAndUpload({ roots: [] });
+    const submit = screen.getByTestId('import-submit-button');
+    expect(submit).toBeDisabled();
+    expect(submit).toHaveAttribute('title', expect.stringContaining('資料集根目錄'));
+  });
+
+  it('clears the red border once user types a non-empty dataset root', async () => {
+    await renderAndUpload({ roots: [] });
+    const input = screen.getByTestId('dataset-root-input') as HTMLInputElement;
+    expect(input).toHaveClass('border-red-500/60');
+    fireEvent.change(input, { target: { value: '2026Q1 北市新檔' } });
+    expect(input.value).toBe('2026Q1 北市新檔');
+    expect(input).not.toHaveClass('border-red-500/60');
+  });
+});

--- a/apps/superadmin/app/superadmin/settings/people-database/import/page.tsx
+++ b/apps/superadmin/app/superadmin/settings/people-database/import/page.tsx
@@ -270,11 +270,48 @@ export function PeopleDatabaseImportWorkspace() {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [selectionNotice, setSelectionNotice] = useState<string | null>(null);
 
+  // Row 146: dataset_root is mandatory. Offer two modes — 沿用既有 (pick from
+  // existing top-level dataset roots) and 新建 (free-text input). Default to
+  // 'new' until we know there's at least one existing root, then auto-flip.
+  const [datasetMode, setDatasetMode] = useState<'new' | 'existing'>('new');
+  const [existingRoots, setExistingRoots] = useState<string[]>([]);
+  const [rootsLoading, setRootsLoading] = useState(false);
+
   useEffect(() => {
     if (folderInputRef.current) {
       folderInputRef.current.setAttribute('webkitdirectory', '');
       folderInputRef.current.setAttribute('directory', '');
     }
+  }, []);
+
+  // Fetch the top-level dataset roots once so the user can pick from a list
+  // instead of re-typing the same root every import.
+  useEffect(() => {
+    let cancelled = false;
+    setRootsLoading(true);
+    fetch('/api/people-db/dataset-tree')
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((data: { tree?: Array<{ label: string; path: string }> }) => {
+        if (cancelled) return;
+        const roots = (data.tree ?? [])
+          .map((n) => n.label?.trim() || n.path?.trim() || '')
+          .filter((s): s is string => !!s);
+        // Stable de-dup, preserve API ordering.
+        const seen = new Set<string>();
+        const unique = roots.filter((r) => (seen.has(r) ? false : (seen.add(r), true)));
+        setExistingRoots(unique);
+        // Auto-flip default to 'existing' once we know at least one root exists.
+        if (unique.length > 0) setDatasetMode('existing');
+      })
+      .catch(() => {
+        // Soft-fail: user can still type a new root.
+      })
+      .finally(() => {
+        if (!cancelled) setRootsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const isSupportedFile = (selectedFile: File) =>
@@ -797,15 +834,73 @@ export function PeopleDatabaseImportWorkspace() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div className="space-y-1">
-                  <label className="text-sm text-text-secondary">資料來源主分類 *</label>
-                  <Input
-                    placeholder="例：企業名錄 / 北市稅籍 / 台北市里長"
-                    value={datasetRoot}
-                    onChange={(e) => setDatasetRoot(e.target.value)}
-                  />
+                <div className="space-y-1 sm:col-span-2" data-testid="dataset-root-field">
+                  <label className="text-sm text-text-primary font-medium">
+                    資料集根目錄 <span className="text-red-500">*</span>
+                  </label>
+                  <div
+                    className="flex flex-wrap gap-3 text-xs text-text-secondary"
+                    role="radiogroup"
+                    aria-label="資料集模式"
+                  >
+                    <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="dataset-mode"
+                        value="existing"
+                        checked={datasetMode === 'existing'}
+                        onChange={() => {
+                          setDatasetMode('existing');
+                          // Reset to first existing root if current value isn't one of them.
+                          if (datasetRoot && !existingRoots.includes(datasetRoot)) {
+                            setDatasetRoot(existingRoots[0] ?? '');
+                          }
+                        }}
+                        disabled={existingRoots.length === 0}
+                      />
+                      沿用既有
+                      {rootsLoading && <span className="text-text-secondary/60">（載入中…）</span>}
+                      {!rootsLoading && existingRoots.length === 0 && (
+                        <span className="text-text-secondary/60">（尚無資料集）</span>
+                      )}
+                    </label>
+                    <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="dataset-mode"
+                        value="new"
+                        checked={datasetMode === 'new'}
+                        onChange={() => setDatasetMode('new')}
+                      />
+                      新建資料集
+                    </label>
+                  </div>
+                  {datasetMode === 'existing' && existingRoots.length > 0 ? (
+                    <select
+                      value={datasetRoot}
+                      onChange={(e) => setDatasetRoot(e.target.value)}
+                      className="w-full rounded-md border border-border-default bg-bg-primary px-3 py-2 text-sm text-text-primary"
+                      data-testid="dataset-root-select"
+                    >
+                      <option value="">— 請選擇 —</option>
+                      {existingRoots.map((r) => (
+                        <option key={r} value={r}>
+                          {r}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <Input
+                      placeholder="例：企業名錄 / 北市稅籍 / 台北市里長"
+                      value={datasetRoot}
+                      onChange={(e) => setDatasetRoot(e.target.value)}
+                      data-testid="dataset-root-input"
+                      className={!datasetRoot.trim() ? 'border-red-500/60' : ''}
+                    />
+                  )}
                   <p className="text-[11px] text-text-secondary/80">
                     選擇資料夾時會自動帶入頂層資料夾名。
+                    <span className="ml-1 text-red-500/80">必填 — 缺值時無法提交。</span>
                   </p>
                 </div>
                 <div className="space-y-1">
@@ -845,7 +940,19 @@ export function PeopleDatabaseImportWorkspace() {
               </Button>
               <Button
                 onClick={handleSubmit}
-                disabled={status === 'submitting' || !mapping['full_name']}
+                disabled={
+                  status === 'submitting' ||
+                  !mapping['full_name'] ||
+                  !datasetRoot.trim()
+                }
+                data-testid="import-submit-button"
+                title={
+                  !datasetRoot.trim()
+                    ? '請先指定資料集根目錄（必填）'
+                    : !mapping['full_name']
+                    ? '請先映射姓名欄位'
+                    : undefined
+                }
               >
                 {status === 'submitting' ? (
                   <><Loader2 className="h-4 w-4 mr-1.5 animate-spin" />提交中…</>

--- a/project-process/dev-logs/dev-people-db-workspace-consolidation-2026-04-19.md
+++ b/project-process/dev-logs/dev-people-db-workspace-consolidation-2026-04-19.md
@@ -49,10 +49,11 @@ Row 131–145 一路堆疊出 5 個獨立 sub-route：
 - [ ] `app/superadmin/tools/page.tsx` 移除「尋人資料庫工具」卡片
 - [ ] `components/layout/nav-items.ts` 將 3 個 people-db entry 合併成單一「尋人資料庫」（指向預設 `?tab=search`）
 
-### Step 3（強制 dataset）
-- [ ] Import workspace：`dataset_root` 必填（紅星 + disable 提交）
-- [ ] 加「新建資料集 / 沿用既有」radio + 既有 dataset dropdown
-- [ ] API `POST /api/people-db/import/*`：schema validation 強制 `dataset_root: z.string().min(1)`
+### Step 3（強制 dataset）✅
+- [x] Import workspace：`dataset_root` 必填（紅星 `*` + 缺值時 `disabled` + helper 紅字「必填 — 缺值時無法提交」）
+- [x] 加「新建資料集 / 沿用既有」radio：`existing` 模式從 `/api/people-db/dataset-tree` fetch top-level roots → `<select>` dropdown；`new` 模式維持自由文字輸入；roots 載入後自動 flip 為 `existing`，roots 為空時 `existing` radio disabled
+- [x] API enforcement：`POST /api/people-db/import/submit` 與 `/import/jobs` 在 column_mapping 檢查後加 `dataset_root` 必填，缺值回 400 帶明確 `Row 146` 提示；移除 `'uncategorized'` fallback dead code
+- [x] 11 cases pass（API submit ×3 / API jobs ×3 / UI ×5）；tsc clean
 
 ### Step 4（scope picker + 顏色標記）
 - [ ] 新增 `lib/people-db/dataset-color.ts`：純函式 `datasetColor(path: string)` HSL hash


### PR DESCRIPTION
Re-created after base branch (feature/row-146-workspace-consolidation) was deleted during PR #42 merge. Original PR was #43.

## Summary
- API enforcement: `/api/people-db/import/submit` 與 `/import/jobs` 強制要求 `dataset_root`，缺值回 400 帶 `Row 146` 提示；移除 `'uncategorized'` fallback dead code
- UI picker: 加「沿用既有 / 新建資料集」radio + dataset 下拉選單；缺值時 input 紅框 + submit disabled + tooltip
- 11 cases pass（API submit ×3 / API jobs ×3 / UI ×5）；jest 247/247 + tsc clean

Full context in dev-log: `project-process/dev-logs/dev-people-db-workspace-consolidation-2026-04-19.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)