### PR TITLE
feat(people-db): tsc build pipeline for CLI workers (Row 145 Sprint 7 #2)

### DIFF
--- a/apps/superadmin/lib/people-db/pdf-parse.ts
+++ b/apps/superadmin/lib/people-db/pdf-parse.ts
@@ -48,9 +48,16 @@ async function loadPdfLib(): Promise<PdfLib> {
   // worker file (which we never actually spawn) satisfies the check.
   if (mod.GlobalWorkerOptions) {
     try {
-      const { createRequire } = await import('node:module');
-      const req = createRequire(import.meta.url);
-      mod.GlobalWorkerOptions.workerSrc = req.resolve('pdfjs-dist/legacy/build/pdf.worker.mjs');
+      // Use Node's synchronous `require.resolve` directly. Works under both:
+      //   (a) Next.js Webpack/Turbopack (injects a `require` runtime helper)
+      //   (b) Plain Node commonjs CLI workers built via tools/people-db/tsconfig.cli.json
+      // The earlier `createRequire(import.meta.url)` form broke the CLI build
+      // because `import.meta` is only valid under ESM tsconfig module targets.
+      // See .claude/rules/critical-deps.md § Node 25 + tsx 已知陷阱.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      mod.GlobalWorkerOptions.workerSrc = require.resolve(
+        'pdfjs-dist/legacy/build/pdf.worker.mjs',
+      );
     } catch {
       // Non-Node environment (e.g. edge runtime) — fall back to a sentinel
       // string so the internal check passes without resolving a real file.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "file-manager:apply": "npm run file-manager:apply --workspace superadmin",
     "file-manager:rollback": "npm run file-manager:rollback --workspace superadmin",
     "file-manager:cleanup": "npm run file-manager:cleanup --workspace superadmin",
+    "build:tools": "tsc --project tools/people-db/tsconfig.cli.json",
     "test:manifest:superadmin": "bash tools/testing/validate-test-manifest.sh",
     "test:nightly:superadmin": "bash tools/testing/run-superadmin-nightly.sh",
     "pwcli:version": "bash tools/testing/playwright-cli.sh --version",

--- a/tools/people-db/ingest.ts
+++ b/tools/people-db/ingest.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env node
 // Row 145 Sprint 6 — Ingestion orchestrator CLI.
 //
 // One entry point to the four stage CLIs. Inserts one row into
@@ -29,6 +29,7 @@ import {
   runOrchestrator,
   type IngestStage,
   type OrchestratorOpts,
+  type SpawnLike,
 } from '../../apps/superadmin/lib/people-db/ingest-orchestrator';
 
 // ---------------------------------------------------------------------------
@@ -111,7 +112,10 @@ async function main(): Promise<void> {
   const outcomes = await runOrchestrator(
     {
       supabase,
-      spawn,
+      // Cast: node:child_process `spawn` has many overloads; TypeScript picks
+      // the args-less signature when the function is passed by reference, which
+      // conflicts with the stricter `SpawnLike` signature the orchestrator expects.
+      spawn: spawn as SpawnLike,
       scriptDir,
       signal: ac.signal,
     },

--- a/tools/people-db/normalize.ts
+++ b/tools/people-db/normalize.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env node
 // Row 145 Sprint 4a Phase 1 — normalize worker CLI.
 //
 // Finds staging rows where `normalized IS NULL`, runs normalizeRecord on

--- a/tools/people-db/parse.ts
+++ b/tools/people-db/parse.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env node
 // Row 145 Sprint 2 — Parser CLI worker.
 //
 // Picks rows from public.people_db_files where status='pending', runs the

--- a/tools/people-db/reindex.ts
+++ b/tools/people-db/reindex.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env node
 // Row 145 Sprint 5 — Blue/green reindex from people_database (v1) to
 // people_database_v2 (IK-tuned mapping).
 //

--- a/tools/people-db/resolve.ts
+++ b/tools/people-db/resolve.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env node
 // Row 145 Sprint 4a Phase 2 — ER resolve worker CLI.
 //
 // For each staging row where `normalized IS NOT NULL AND resolved_at IS NULL`:

--- a/tools/people-db/scan.ts
+++ b/tools/people-db/scan.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env node
 // Row 145 Sprint 1 — File Inventory scanner CLI.
 //
 // Recursively walks $PEOPLE_DB_SOURCE_ROOT (or --root <path>), computes sha256

--- a/tools/people-db/tsconfig.cli.json
+++ b/tools/people-db/tsconfig.cli.json
@@ -1,0 +1,59 @@
+{
+  // Row 145 Sprint 7 — CLI build config.
+  //
+  // Compiles tools/people-db/*.ts (5 CLI workers) + apps/superadmin/lib/people-db/**/*.ts
+  // (their lib dependencies) to plain .js under dist/, so CLIs can run on plain
+  // `node` instead of `tsx`. This avoids the tsx + Node 25 + barrel import +
+  // supabase-js module-load crash hit during Sprint 2b Task F (see
+  // .claude/rules/critical-deps.md § Node 25 + tsx 已知陷阱).
+  //
+  // Output layout (rootDir preserves repo-relative structure under outDir):
+  //   dist/tools/people-db/scan.js
+  //   dist/apps/superadmin/lib/people-db/inventory.js
+  // Relative import "../../apps/superadmin/lib/people-db/inventory" from
+  // dist/tools/people-db/ resolves to dist/apps/superadmin/lib/people-db/inventory.js
+  // correctly because rootDir + outDir preserve the two-level climb.
+  //
+  // Kept to `commonjs` + `moduleResolution: node` to avoid forcing .js extensions
+  // on every relative import (matches tools/local-agent/tsconfig.json).
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "sourceMap": true,
+    "noEmitOnError": true,
+    "rootDir": "../..",
+    "outDir": "../../dist"
+  },
+  "include": [
+    "../../tools/people-db/scan.ts",
+    "../../tools/people-db/parse.ts",
+    "../../tools/people-db/normalize.ts",
+    "../../tools/people-db/resolve.ts",
+    "../../tools/people-db/ingest.ts",
+    "../../tools/people-db/reindex.ts",
+    "../../apps/superadmin/lib/people-db/**/*.ts",
+    // Ambient declarations for pg-copy-streams (used by staging-copy.ts).
+    "../../apps/superadmin/types/**/*.d.ts"
+  ],
+  // Exclude globs are relative to this tsconfig's directory (tools/people-db/).
+  // Explicit "../../" prefix is required to match files brought in via include.
+  "exclude": [
+    "**/node_modules/**",
+    "../../apps/superadmin/lib/people-db/__tests__/**",
+    "../../apps/superadmin/lib/people-db/**/*.test.ts",
+    "../../apps/superadmin/lib/people-db/**/*.test.tsx",
+    // import-jobs.ts uses Next.js "@/" path alias which is not resolvable outside
+    // the Next.js build; it isn't imported by any of the 5 CLI workers, so safe to skip.
+    "../../apps/superadmin/lib/people-db/import-jobs.ts",
+    // sprint-2b-validate.ts is a one-off standalone CLI that intentionally keeps its
+    // own tsx-based shebang and bypasses the barrel; don't let tsc compile it.
+    "../../tools/people-db/sprint-2b-validate.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

將 `tools/people-db/` 下 6 支 CLI (`scan` / `parse` / `normalize` / `resolve` / `ingest` / `reindex`) 改為 **tsc 編譯後 plain node 執行**，取代 `#!/usr/bin/env -S npx tsx`。

徹底繞過 Sprint 2b Task F 在 Node 25.2.1 + tsx 下撞到的 module-load crash (`Cannot assign to read only property 'valueOf'/'toString'`) — 該 crash 的前提之一是 tsx 本身，只要把 tsx 從 runtime path 移除就不觸發。

完成 Row 145 roadmap 裡 Sprint 7 計畫的第 2 項（「parse.ts 改 tsc 編譯後 node 執行」）。

## Smoke test (Node.js 25.2.1)

```
$ node dist/tools/people-db/scan.js --dry-run --root /tmp/smoke --limit 1
Scanning /tmp/smoke (dry run)...
ERROR /tmp/smoke/foo.txt: File must live under a dataset root folder: ...
Done in 0.0 s
{ scanned: 1, errors: 1, inserted: 0, ... }
```

→ module load + env init + parseArgs + scan loop + summary 全走完，exit 0，**沒觸發 valueOf/toString crash**。

## 新增 / 變更

| 檔案 | 變更 | 原因 |
|---|---|---|
| `tools/people-db/tsconfig.cli.json` (new) | commonjs + moduleResolution:node、rootDir=repo-root、outDir=`dist/` | 跨 workspace relative import 需 repo-root 編譯保留結構 |
| `package.json` | 新增 `scripts.build:tools` | 入口 |
| `tools/people-db/{scan,parse,normalize,resolve,ingest,reindex}.ts` | shebang `npx tsx` → `node` | tsc 自動保留到 compiled .js |
| `tools/people-db/ingest.ts` | `spawn as SpawnLike` cast + import `SpawnLike` type | tsc strict 下的 Node spawn overload ambiguity |
| `apps/superadmin/lib/people-db/pdf-parse.ts` | `createRequire(import.meta.url)` → `require.resolve()` | `import.meta` 只在 ESM tsconfig 下合法；commonjs 下 `require` 全域可用，Next.js bundler 也 inject 同名 helper |

## 編譯輸出結構

```
dist/
├── tools/people-db/          ← 6 支 compiled CLI + shebang=node
│   ├── scan.js
│   ├── parse.js
│   └── ...
└── apps/superadmin/lib/people-db/
    ├── inventory.js
    ├── parsers/
    │   └── dbf-stream.js
    └── ...
```

Relative import `../../apps/superadmin/lib/people-db/inventory` 從 `dist/tools/people-db/` 上兩層到 `dist/`，再走 `apps/superadmin/lib/people-db/inventory` ✓ 結構對齊，無需 path mapping。

## Regression

- [x] `npm test --workspace superadmin -- lib/people-db` → **238 passed** / 2 skipped integration / 1 skipped suite
- [x] `npx tsc --noEmit --project apps/superadmin/tsconfig.json` → **0 errors**
- [x] `npm run build:tools` → tsc 0 errors
- [x] Smoke test on Node 25.2.1 → exit 0

## Out of scope (Phase 4, 另排 session)

- CI / `start.sh` 接入 `npm run build:tools` 前置
- 1+ GB DBF 真實檔在 compiled pipeline 跑一次（12+ min wall clock）
- `sprint-2b-validate.ts` 因為是 Sprint 2b 的 one-off 驗證，保留 tsx shebang 不納入本 build（tsconfig exclude）

## Test plan

- [x] tsc / jest / smoke test 自動化
- [ ] Reviewer 可自行 `npm run build:tools && node dist/tools/people-db/scan.js --dry-run --root /tmp/x --limit 1` 驗證
- [ ] Merge 後，下一個 session 接 Phase 4（CI / start.sh 接入）

## 背景

[.claude/rules/critical-deps.md § Node 25 + tsx 已知陷阱](.claude/rules/critical-deps.md) — 本 PR 的「有效繞法 #3」

🤖 Generated with [Claude Code](https://claude.com/claude-code)