### PR TITLE
docs(handoff): enforce handoff skill invocation + session-end rule

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,6 +1,27 @@
 根據本次對話已完成的工作，寫一份**自包含**的接手 prompt 給下一個 AI session 使用。
 使用者會開新 session 把你的輸出整份貼進去，新 AI 必須**從零**就能理解並直接動工。
 
+## 觸發條件（以下表達都必須呼叫本 skill，不得 ad-hoc 手寫）
+
+凡看到以下任一表達，**都是本 skill 的觸發訊號**，必須用 Skill tool 呼叫 `handoff`（或視為此 command 已被呼叫），不得略過：
+
+- 直接輸入 `/handoff`
+- 「寫 handoff」「handoff prompt」「寫接手 prompt」「接手 prompt」
+- 「給下一個 session / AI 的指引 / 交接 / 接手」「留訊息給下個 session」
+- 使用者在 session 尾端要求「收尾」「結束前交代一下」「handoff 一下」
+- 使用者已同意「選項 X = 做收尾 / 寫 handoff」等複合指令中含 handoff 語意
+- 你自己判斷 session 即將結束且本 session 有重大交付（PR merged、新檔落地、Sprint 推進）未落地
+
+**絕對禁止**以下反模式：
+
+- ❌ 在 chat 訊息裡自己手寫一份 markdown 當成 handoff，卻沒實際呼叫本 skill
+- ❌ 只產 chat fenced block、略過「B. 同時存成檔案」部分
+- ❌ 用「建議你存檔到 `/tmp/xxx.md`」這種口頭引導取代實際 `Write` 工具落地
+
+違反任一條 → handoff 只存在對話 log，session 結束即消失 → 等於沒寫，下一個 AI 無法接手。
+
+**AI 工程師自檢**：如果你正打算「自己在訊息裡寫 handoff 內容」而沒呼叫此 skill 或動 `Write` 工具 → **立即停手** → 改用 Skill tool 呼叫 `handoff`，或至少把本檔規則全部跑一次（尤其「完成檢查清單」最末段）。
+
 ## 動筆前必做的現場偵察
 
 這些是**必跑**，不是可選：

--- a/.claude/rules/general.md
+++ b/.claude/rules/general.md
@@ -109,6 +109,36 @@
 
 ---
 
+## Session 結束規範（強制 handoff 落地）
+
+Session 收尾時，**若本 session 有以下任一交付**，**必須**呼叫 `/handoff` skill 產出接手紀錄，不得以「在 chat 訊息裡手寫 markdown」替代：
+
+- 有 PR 被 merged（特別是 Sprint 推進或功能落地的 PR）
+- 新增 `project-process/features/`、`project-process/dev-logs/`、`supabase/migrations/` 等結構性檔案
+- Roadmap `percentage` 推進或 Sprint 完成
+- 有明確的「下一步任務」尚未動工（下個 session 需要接手）
+
+### 判斷流程
+
+1. Session 內有上述任一項 ✓ → **走 `/handoff` skill**（詳見 `.claude/commands/handoff.md` 的「觸發條件」與「完成檢查清單」）
+2. 使用者已用自然語言暗示（「收尾」「handoff」「寫接手 prompt」「給下個 session 的指引」「選項 X = 收尾」）→ **走 `/handoff` skill**（不得視為普通請求在 chat 裡手寫）
+3. 僅修小 bug、純 docs typo、單一 refactor 且沒「下一步」→ 可略過（留 commit message 就夠）
+
+### 落地驗證
+
+`/handoff` skill 會要求：
+- Chat 輸出 fenced markdown block（給 user 複製）
+- **同時** `Write` tool 落地到 `project-process/handoffs/handoff-{topic}-{YYYYMMDD}.md`
+- `ls project-process/handoffs/` 確認檔案存在
+
+**兩件事都要做，缺一不可**（命名 pattern + 檔案結構見 handoff.md）。
+
+### 為什麼強制
+
+Chat 輸出會隨 session 結束消失。只口頭 handoff → 下次開新 session 時 user 找不到、要重新挖 session log → context 斷層 → 新 AI 接手效率大跌。檔案進 git 後永久可追溯、儀表板可 cross-link、search 可索引。
+
+---
+
 ## 除錯備註
 
 - 本機服務連不上（瀏覽器 vs macOS vs server 分層 triage）→ `docs/operational-guides/localhost-debug-triage.md`


### PR DESCRIPTION
## Summary

本 session 收尾時我（AI）用 **ad-hoc 方式在 chat 裡手寫 handoff markdown**，沒呼叫 `.claude/commands/handoff.md` 定義的 `/handoff` skill，導致檔案沒被 `Write` 工具落地到 `project-process/handoffs/`。

Jason 指出問題後（PR #53 是事後補救），我診斷根因：**command 寫得再完整，AI 沒辨識出觸發訊號就不會被呼叫**。

本 PR 加兩層保險。

## 改動

### 1. `.claude/commands/handoff.md` 加「觸發條件」章節

- **位置**：放在原開頭段落**之後**（保留第 1 行原文當 skill description，避免被新 H2 header 取代成模糊的「觸發條件...」）
- **內容**：
  - 6 類應觸發 skill 的表達（含自然語言變體：「寫 handoff」「handoff prompt」「接手 prompt」「收尾」「結束前交代一下」，以及複合指令「選項 X = 做收尾 / 寫 handoff」）
  - 3 類絕對禁止的反模式（ad-hoc 手寫 / 只產 chat block 沒落地 / 用「建議你存到 `/tmp/`」取代實際 `Write`）
  - AI 工程師自檢規則：發現自己正打算手寫時必須立即停手改呼叫 skill

### 2. `.claude/rules/general.md` 加「Session 結束規範」章節

- **位置**：「工作日誌 / 進度更新」之後、「除錯備註」之前
- **內容**：
  - 必走 `/handoff` 的 4 類交付（PR merged / 新增結構性檔案 / Sprint 推進 / 有下一步任務未動工）
  - 判斷流程 3 步（含使用者自然語言暗示的處理）
  - 落地驗證規則（chat fenced + `Write` 工具 + `ls` 確認）
  - 解釋「為什麼強制」（chat 輸出會隨 session 消失）

## 為什麼兩層

- `handoff.md`「觸發條件」：**AI 被要求寫 handoff 時**檔案會被載入 → 讀到規則 → 正確呼叫
- `general.md`「Session 結束規範」：**AI 決定收尾時**會讀 rules → 主動辨識該走 /handoff
- 兩層交叉覆蓋，不管 AI 是被動（user 說「handoff」）還是主動（自己判斷 session 即將結束）都會被 catch

## 不改動的東西

- **`.claude/commands/commit-push-pr.md`** — Jason 有 uncommitted WIP（`--cleanup-branch` 擴充），本 PR 不碰（保持 unstaged）
- **`.claude/commands/handoff.md` 中段的 Full-Auto 最小必要輸出模式** — 那是 Jason stash 暫存的 WIP，本 PR 用 `git stash` 機制避開，他 `git stash pop` 後仍在

## Test plan

- [x] `head -2 .claude/commands/handoff.md` 確認原描述保留（skill description 不被污染）
- [x] Selective `git add` 只含我的兩個檔，diff stat +51/0（無刪除，純 append）
- [x] 沒動其他 code 檔，無 regression 風險
- [ ] Reviewer 實測：merge 後下個 session 對 AI 說「寫 handoff 給下個 session」，應該會看到 AI 呼叫 /handoff skill 而非在 chat 裡手寫

## 關聯 PR

- PR #53（docs/handoff-row-145-sprint-7-step3-20260420）：本 session 漏做的 handoff 檔案事後補救，功能性完成；本 PR 解根本原因，防止下次再發生

🤖 Generated with [Claude Code](https://claude.com/claude-code)