### PR TITLE
feat(ai-settings): Row 100 HTTP adapter 比較與純 CLI/HTTP 降級鏈

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,34 +1,102 @@
 # Commit Push PR
 
-用於「開發完成後、PR 建立前」的前段流程：分析變更 → commit → push → 建立 PR。
+根據目前的 git diff 與 untracked files，執行整合流程（commit → PR → merge/cleanup → handoff）。
 
-## 流程
+## 適用參數
 
-1. 執行 `git status` 與 `git diff`，分析變更與風險。
+- `--pr` / `--pull-request`：建立 PR
+- `--auto-merge`：建立 PR 後自動檢查並嘗試合併
+- `--cleanup` / `--cleanup-branch` / `--delete-branch`：PR 合併後清理分支
+- `--handoff`：產出 handoff
+- `--full-auto`：等同 `--pr --auto-merge --cleanup --handoff`
+
+## 步驟一：Commit 與 Push
+
+1. 執行 `git status` 與 `git diff`，分析變更。
 2. 排除敏感檔案（如 `.env`、`credentials.json`），不得加入 staging。
 3. 逐檔 `git add`（避免 `git add -A`）。
 4. 優先維持「單一主題、單一 commit」：
    - 若變更跨多個主題，先拆成多個邏輯清楚的 commit。
-   - 讓 reviewer 與後續 squash 都能保留清楚脈絡。
+   - 目標是讓最終 squash 後仍保留清楚脈絡。
 5. 產生 commit message：`<type>: <繁體中文描述>`。
    - type: feat / fix / docs / refactor / style / test / chore
-   - 若使用者提供 `$ARGUMENTS` 文案，優先採用並做必要潤飾
+   - 若使用者提供 `$ARGUMENTS`，可作為 message 或補充說明
 6. 執行 commit。
 7. push 到目前分支（若無 upstream，使用 `-u` 設定）。
-8. 當 `$ARGUMENTS` 含 `--pr` 或 `--pull-request` 時，建立 PR：
-   - 先用 `git log` 與 `git diff main...HEAD` 整理 PR 內容
-   - 用 `gh pr create` 建立 PR
-   - PR Body 需包含 Summary / Test plan，並建議使用 Squash and merge
-   - 回報 PR URL
 
-## 與其他命令的分工
+## 步驟二：建立 PR（可選）
 
-- 本命令只處理 commit、push、PR 建立。
-- merge、cleanup、handoff 由 `/commit-push-pr-merge-cleanup-handoff` 負責。
+當 `$ARGUMENTS` 含 `--pr` 或 `--pull-request` 時執行。
+
+1. 用 `git log` 與 `git diff main...HEAD` 分析 commits。
+2. 用 `gh pr create` 建立 PR。
+   - Title：簡短描述（建議 < 70 字元）
+   - 合併策略預設：優先使用 Squash and merge
+   - 若分支有多個 commit，PR Body 必須註記建議採用 squash
+3. PR Body 建議格式：
+
+```markdown
+## Summary
+- <變更摘要>
+
+## Test plan
+- [ ] <測試項目>
+
+## Merge strategy
+- 建議使用 Squash and merge
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+4. 回報 PR URL。
+
+若未提供 `--pr`，只執行步驟一。
+
+## 步驟三：審核與合併（可選）
+
+當 `$ARGUMENTS` 含 `--auto-merge` 或 `--full-auto` 時執行。
+
+1. 用 `gh pr view --json` 讀取狀態（`mergeStateStatus`、`isDraft`、`reviewDecision`、`statusCheckRollup`）。
+2. 僅在以下條件全成立時自動 merge：
+   - PR 非 draft
+   - 無 conflict（可合併）
+   - CI 全綠
+   - 無 `CHANGES_REQUESTED`
+3. 條件符合時執行：`gh pr merge --squash --delete-branch=false`。
+4. 若無法自動 merge（權限或 repo 設定），需明確提示 reviewer 以 Squash and merge 手動合併。
+5. 條件不符合時，回報阻塞原因並停在 PR 階段（不執行 cleanup）。
+
+## 步驟四：清理分支（可選）
+
+當 `$ARGUMENTS` 含 `--cleanup`、`--cleanup-branch`、`--delete-branch` 或 `--full-auto` 時執行。
+
+1. 先確認 PR 已完成 review、CI 通過，且已 merge 到 `main`。
+2. 取得目前分支並做防呆：
+   - 禁止刪除 `main`、`master`、`develop`
+   - 若仍在目標分支，先切回 `main` 並 `git pull`
+3. 刪除遠端分支：`git push origin --delete <branch>`。
+4. 刪除本地分支（安全模式）：`git branch -d <branch>`。
+5. 回報本地與遠端刪除結果。
+
+若 PR 未 merge，僅提示目前不可刪除分支並跳過。
+
+## 步驟五：產出 Handoff（可選）
+
+當 `$ARGUMENTS` 含 `--handoff` 或 `--full-auto` 時執行。
+
+1. 依 `.claude/commands/handoff.md` 規範產出 handoff prompt。
+   - 若由 `--full-auto` 觸發，預設採用 Full-Auto 最小必要輸出模式
+2. 輸出 handoff 工作交接檔。
+3. 路徑格式：`project-process/handoffs/handoff-{topic}-{YYYYMMDD}.md`。
+4. 回報 handoff 實際路徑。
+
+若 PR 檢查階段被阻塞，handoff 仍需產出並記錄阻塞原因與待辦。
 
 ## 注意事項
 
 - 不要 commit 含 secrets 的檔案
 - 不要 force push
 - 不要 amend 既有 commit（除非明確要求）
+- 不要刪除保護分支（`main` / `master` / `develop`）
 - commit message 的描述部分使用繁體中文
+- PR 合併策略預設採用 squash（自動與人工合併皆相同）

--- a/.claude/rules/backend/ai-adapter.md
+++ b/.claude/rules/backend/ai-adapter.md
@@ -52,13 +52,9 @@
 
 `lint-adapter-model-ids.sh` 內含 `LEGACY_EXEMPTIONS` Set，列出**預存**於 lint 出現前的違規 row，允許短期豁免（印 warning 但不 fail）。
 
-當前豁免清單（截至 2026-04-19）：
+當前豁免清單（截至 2026-04-21）：
 
-- `kilo-dola-seed-2-0-pro`
-- `kilo-qwen-3-6-plus`
-- `opencode-kimi-k2-5`
 - `opencode-glm-5-1`
-- `opencode-qwen-3-6-plus`
 
 **處理流程**：Row 100 P1 baseline self-report 盤點會逐一確認模型真實 id，修正後於**同一個 PR**中：
 

--- a/apps/superadmin/app/api/ai-settings/adapter-runs/route.ts
+++ b/apps/superadmin/app/api/ai-settings/adapter-runs/route.ts
@@ -17,9 +17,23 @@ import { createAdminClient } from '@/utils/supabase/admin';
 import { decryptApiKey } from '@/lib/crypto';
 import { AI_PROVIDERS, type AIProvider } from '@/lib/ai-providers';
 import { shouldUseApiFallback } from '@/lib/adapter-runs/fallback';
+import { isAdapterRunMetaContent } from '@/lib/adapter-runs/adapter-run-meta-lines';
 import { extractChatCompletionAssistantText } from '@/lib/adapter-runs/extract-chat-completion-text';
+import { extractOpenAiResponsesOutputText } from '@/lib/adapter-runs/extract-openai-responses-text';
 import { ADAPTER_CONFIG_ITEMS, DEFAULT_ADAPTER_TEST_PROMPT } from '@/lib/adapter-config';
+import {
+  KILO_GATEWAY_BASE,
+  OPENCODE_ZEN_CHAT_COMPLETIONS_URL,
+  openCodeZenChatModelId,
+} from '@/lib/ai-key-validation/kilo-opencode-zen';
 import { pickRecommendedModelByProvider } from '@/lib/pick-latest-model';
+
+/**
+ * Chained fallback design (2026-04-21): CLI mode only retries through more CLI attempts,
+ * HTTP mode only retries through more HTTP attempts. Cross-path fallback (CLI→HTTP) is
+ * removed so the CLI-vs-HTTP speed/stability comparison on the settings page stays honest.
+ * Each adapter row supplies its downgrade chain via `fallbackModels` in adapter-config.ts.
+ */
 
 export const runtime = 'nodejs';
 
@@ -31,13 +45,21 @@ type ActiveRun = {
   adapterId: string;
   provider: AdapterProvider;
   status: RunStatus;
-  process: AdapterChildProcess;
+  mode: 'cli' | 'http';
+  process: AdapterChildProcess | null;
   command: string;
   logs: string[];
   resultText: string;
   requestedModel: string;
   effectiveModel: string;
   modelSource: string;
+  ttftMs: number | null;
+  e2eLatencyMs: number | null;
+  tokensPerSec: number | null;
+  httpStatus: number | null;
+  retryCount: number;
+  errorType: string;
+  successRateRecent: number | null;
   createdAt: number;
   updatedAt: number;
   tempDir?: string;
@@ -45,7 +67,9 @@ type ActiveRun = {
 };
 
 const activeRuns = new Map<string, ActiveRun>();
+const runHistoryByAdapter = new Map<string, boolean[]>();
 const MAX_LOG_LINES = 300;
+const HISTORY_WINDOW = 10;
 const PROVIDER_ENV_KEY = Object.fromEntries(
   AI_PROVIDERS.map((p) => [p.id, p.envKey])
 ) as Record<AIProvider, string>;
@@ -61,8 +85,35 @@ function pushLog(run: ActiveRun, line: string): void {
   run.updatedAt = Date.now();
 }
 
+function getSuccessRateRecent(runKey: string): number | null {
+  const arr = runHistoryByAdapter.get(runKey) ?? [];
+  if (arr.length === 0) return null;
+  const successCount = arr.filter(Boolean).length;
+  return successCount / arr.length;
+}
+
+function pushRunHistory(runKey: string, success: boolean): number | null {
+  const arr = runHistoryByAdapter.get(runKey) ?? [];
+  arr.push(success);
+  if (arr.length > HISTORY_WINDOW) arr.splice(0, arr.length - HISTORY_WINDOW);
+  runHistoryByAdapter.set(runKey, arr);
+  return getSuccessRateRecent(runKey);
+}
+
 function stripAnsi(raw: string): string {
   return raw.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+/** `adapter-config` 用 `openrouter/<vendor>/<id>`；OpenRouter HTTP API 的 `model` 須為 `<vendor>/<id>`。 */
+function openRouterModelForApiRequest(model: string): string {
+  return model.startsWith('openrouter/') ? model.slice('openrouter/'.length) : model;
+}
+
+/** Kilo Gateway / OpenCode Zen `chat/completions`：剝除 aggregator 前綴，避免重複前綴或格式不符。 */
+function aggregatorModelForOpenAiChat(model: string): string {
+  if (model.startsWith('openrouter/')) return model.slice('openrouter/'.length);
+  if (model.startsWith('opencode/')) return model.slice('opencode/'.length);
+  return model;
 }
 
 function deriveResultFromLogs(lines: string[]): string {
@@ -85,6 +136,7 @@ function deriveResultFromLogs(lines: string[]): string {
     .map((line) => line.replace(/^\[\d{2}:\d{2}:\d{2}\]\s*/, '').trim())
     .map((line) => line.replace(/^\[stderr\]\s*/i, '').trim())
     .filter(Boolean)
+    .filter((line) => !isAdapterRunMetaContent(line))
     .filter((line) => !ignored.some((p) => p.test(line)));
   if (!cleaned.length) return '';
   return cleaned[cleaned.length - 1] ?? '';
@@ -149,172 +201,292 @@ async function cleanupTemp(run: ActiveRun): Promise<void> {
   }
 }
 
-async function runAnthropicApiFallback(prompt: string, anthropicApiKey?: string): Promise<string> {
-  if (!anthropicApiKey) return '無可用 ANTHROPIC_API_KEY，無法執行 API fallback。';
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'x-api-key': anthropicApiKey,
-      'anthropic-version': '2023-06-01',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 120,
-      messages: [{ role: 'user', content: prompt }],
-    }),
-  });
-  const data = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const msg = (data as { error?: { message?: string } }).error?.message ?? `HTTP ${response.status}`;
-    return `Anthropic API fallback 失敗：${msg}`;
-  }
-  const text = (data as { content?: Array<{ text?: string }> }).content?.[0]?.text?.trim();
-  return text ? `Anthropic API fallback 成功：${text}` : 'Anthropic API fallback 成功，但無文字輸出。';
+function classifyHttpError(status: number | null, message: string): string {
+  if (/timeout/i.test(message)) return 'timeout';
+  if (status === 429) return '429';
+  if (status != null && status >= 500) return '5xx';
+  if (status != null && status >= 400) return '4xx';
+  if (/schema/i.test(message)) return 'schema';
+  if (/empty output|無輸出/i.test(message)) return 'empty_output';
+  return message ? 'runtime_error' : '';
 }
 
-async function runOpenAiCompatFallback(
-  prompt: string,
-  endpoint: string,
-  model: string,
-  apiKey?: string
-): Promise<string> {
-  if (!apiKey) return '缺少 API key，無法執行 fallback。';
-  const useResponsesApi = /\/v1\/chat\/completions$/.test(endpoint) && /^gpt-5/i.test(model);
-  const finalEndpoint = useResponsesApi
-    ? endpoint.replace(/\/v1\/chat\/completions$/, '/v1/responses')
-    : endpoint;
-  const body = useResponsesApi
-    ? {
-        model,
-        input: prompt,
-        max_output_tokens: 120,
-      }
-    : {
-        model,
-        messages: [{ role: 'user', content: prompt }],
-        // OpenRouter 推理模型可能先耗用 token 在 reasoning；120 易導致 content 與 reasoning 皆空
-        max_tokens: /openrouter\.ai/i.test(endpoint) ? 1024 : 120,
-      };
-  const response = await fetch(finalEndpoint, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
-  });
-  const data = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const msg = (data as { error?: { message?: string } }).error?.message ?? `HTTP ${response.status}`;
-    return `OpenAI-compatible fallback 失敗：${msg}`;
-  }
-  const text = useResponsesApi
-    ? ((data as { output_text?: string }).output_text?.trim() ||
-      (Array.isArray((data as { output?: Array<{ content?: Array<{ text?: string }> }> }).output)
-        ? ((data as { output: Array<{ content?: Array<{ text?: string }> }> }).output
-            .flatMap((o) => o.content ?? [])
-            .map((c) => c.text ?? '')
-            .join('')
-            .trim())
-        : ''))
-    : extractChatCompletionAssistantText(data);
-  return text ? `API fallback 成功：${text}` : 'API fallback 成功，但無文字輸出。';
-}
-
-async function runGeminiFallback(prompt: string, geminiApiKey?: string): Promise<string> {
-  if (!geminiApiKey) return '缺少 GEMINI_API_KEY，無法執行 fallback。';
-  return runGeminiFallbackWithModel(prompt, 'gemini-2.0-flash', geminiApiKey);
-}
-
-async function runGeminiFallbackWithModel(prompt: string, model: string, geminiApiKey?: string): Promise<string> {
-  if (!geminiApiKey) return '缺少 GEMINI_API_KEY，無法執行 fallback。';
-  const modelName = model.startsWith('models/') ? model : `models/${model}`;
-  const response = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/${modelName}:generateContent?key=${geminiApiKey}`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        contents: [{ parts: [{ text: prompt }] }],
-        generationConfig: { maxOutputTokens: 120 },
-      }),
-    }
-  );
-  const data = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const msg = (data as { error?: { message?: string } }).error?.message ?? `HTTP ${response.status}`;
-    return `Gemini API fallback 失敗：${msg}`;
-  }
-  const text = (data as { candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> })
-    .candidates?.[0]?.content?.parts
-    ?.map((p) => (typeof p.text === 'string' ? p.text : ''))
-    .join('')
-    .trim();
-  if (text) return `Gemini API fallback 成功：${text}`;
-
-  const blockReason = (data as { promptFeedback?: { blockReason?: string } }).promptFeedback?.blockReason;
-  if (blockReason) {
-    return `Gemini API fallback 無輸出：prompt 被阻擋（${blockReason}）`;
-  }
-  const finishReason = (data as { candidates?: Array<{ finishReason?: string }> })
-    .candidates?.[0]?.finishReason;
-  if (finishReason) {
-    return `Gemini API fallback 無輸出：finishReason=${finishReason}`;
-  }
-  return 'Gemini API fallback 無輸出：回應成功但未取得可讀文字。';
-}
-
-async function runProviderFallback(
-  provider: AdapterProvider,
+/**
+ * Single HTTP attempt for `model`. Mutates `run` in place with latest attempt's metrics
+ * (httpStatus, ttftMs, tokensPerSec, resultText, errorType). Wall time is not tracked here;
+ * the enclosing {@link runHttpChain} accumulates cumulative e2e across attempts.
+ */
+async function runHttpAttempt(
+  run: ActiveRun,
   prompt: string,
   env: Record<string, string>,
-  fallbackModel: string
-): Promise<string> {
-  if (provider === 'claude') {
-    // Anthropic messages API model comes from fallbackModel when resolved.
-    if (!env.ANTHROPIC_API_KEY) return '缺少 ANTHROPIC_API_KEY，無法執行 fallback。';
-    const response = await fetch('https://api.anthropic.com/v1/messages', {
-      method: 'POST',
-      headers: {
-        'x-api-key': env.ANTHROPIC_API_KEY,
-        'anthropic-version': '2023-06-01',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: fallbackModel,
-        max_tokens: 120,
-        messages: [{ role: 'user', content: prompt }],
-      }),
-    });
-    const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      const msg = (data as { error?: { message?: string } }).error?.message ?? `HTTP ${response.status}`;
-      return `Anthropic API fallback 失敗：${msg}`;
+  model: string
+): Promise<void> {
+  const startedAt = Date.now();
+  /** gpt-5 系推理較慢；25s 易 AbortError，與 max_output 一併放寬 */
+  const timeoutMs = run.provider === 'codex' && /^gpt-5/i.test(model) ? 120_000 : 25_000;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let text = '';
+  let statusCode: number | null = null;
+  try {
+    pushLog(run, `HTTP 執行中：provider=${run.provider}, model=${model}`);
+    if (run.provider === 'claude') {
+      const res = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'x-api-key': env.ANTHROPIC_API_KEY ?? '',
+          'anthropic-version': '2023-06-01',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 320,
+          messages: [{ role: 'user', content: prompt }],
+        }),
+        signal: controller.signal,
+      });
+      statusCode = res.status;
+      const data = await res.json().catch(() => ({}));
+      text = (data as { content?: Array<{ text?: string }> }).content?.[0]?.text?.trim() ?? '';
+      if (!res.ok) {
+        const msg = (data as { error?: { message?: string } }).error?.message ?? `HTTP ${res.status}`;
+        throw new Error(msg);
+      }
+    } else if (run.provider === 'gemini') {
+      const modelName = model.startsWith('models/') ? model : `models/${model}`;
+      const res = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/${modelName}:generateContent?key=${env.GEMINI_API_KEY ?? ''}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            contents: [{ parts: [{ text: prompt }] }],
+            generationConfig: { maxOutputTokens: 320 },
+          }),
+          signal: controller.signal,
+        }
+      );
+      statusCode = res.status;
+      const data = await res.json().catch(() => ({}));
+      text = (data as { candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> })
+        .candidates?.[0]?.content?.parts
+        ?.map((p) => p.text ?? '')
+        .join('')
+        .trim() ?? '';
+      if (!res.ok) {
+        const msg = (data as { error?: { message?: string } }).error?.message ?? `HTTP ${res.status}`;
+        throw new Error(msg);
+      }
+    } else {
+      let endpoint: string;
+      let apiKey: string | undefined;
+      switch (run.provider) {
+        case 'codex':
+          endpoint = 'https://api.openai.com/v1/chat/completions';
+          apiKey = env.OPENAI_API_KEY;
+          break;
+        case 'kilo':
+          endpoint = `${KILO_GATEWAY_BASE}/chat/completions`;
+          apiKey = env.KILO_API_KEY;
+          break;
+        case 'opencode':
+          endpoint = OPENCODE_ZEN_CHAT_COMPLETIONS_URL;
+          apiKey = env.OPENCODE_API_KEY;
+          break;
+      }
+      const useResponsesApi = run.provider === 'codex' && /^gpt-5/i.test(model);
+      const finalEndpoint = useResponsesApi ? 'https://api.openai.com/v1/responses' : endpoint;
+      const hitsOpenRouter = finalEndpoint.includes('openrouter.ai');
+      const hitsOpenCodeZen = finalEndpoint.includes('opencode.ai');
+      const apiModel = hitsOpenRouter
+        ? openRouterModelForApiRequest(model)
+        : hitsOpenCodeZen
+          ? openCodeZenChatModelId(model)
+          : aggregatorModelForOpenAiChat(model);
+      const chatMaxTokens = run.provider === 'codex' && !useResponsesApi ? 320 : 2048;
+      const body = useResponsesApi
+        ? { model: apiModel, input: prompt, max_output_tokens: 2048 }
+        : {
+            model: apiModel,
+            messages: [{ role: 'user', content: prompt }],
+            max_tokens: chatMaxTokens,
+          };
+      const res = await fetch(finalEndpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey ?? ''}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      statusCode = res.status;
+      const data = await res.json().catch(() => ({}));
+      text = useResponsesApi
+        ? extractOpenAiResponsesOutputText(data)
+        : extractChatCompletionAssistantText(data);
+      if (!res.ok) {
+        const msg = (data as { error?: { message?: string } }).error?.message ?? `HTTP ${res.status}`;
+        throw new Error(msg);
+      }
     }
-    const text = (data as { content?: Array<{ text?: string }> }).content?.[0]?.text?.trim();
-    return text ? `Anthropic API fallback 成功：${text}` : 'Anthropic API fallback 成功，但無文字輸出。';
+    const attemptMs = Date.now() - startedAt;
+    run.httpStatus = statusCode;
+    run.ttftMs = attemptMs;
+    run.tokensPerSec = text ? Math.max(text.length / Math.max(1, attemptMs / 1000), 0) : null;
+    run.resultText = text;
+    run.errorType = text ? '' : 'empty_output';
+    pushLog(run, text ? `HTTP 回應成功（${text.length} chars）` : 'HTTP 回應成功，但無輸出');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'HTTP run failed';
+    run.httpStatus = statusCode;
+    run.ttftMs = null;
+    run.tokensPerSec = null;
+    run.resultText = '';
+    run.errorType = classifyHttpError(statusCode, message);
+    pushLog(run, `HTTP 失敗：${message}`);
+  } finally {
+    clearTimeout(timeout);
   }
-  if (provider === 'gemini') {
-    return runGeminiFallbackWithModel(prompt, fallbackModel || 'gemini-2.0-flash', env.GEMINI_API_KEY);
+}
+
+/**
+ * Run HTTP attempts down the fallback chain until one succeeds or the chain exhausts.
+ * CLI-mode uses its own chain ({@link runCliChain}); no cross-path fallback.
+ */
+async function runHttpChain(
+  run: ActiveRun,
+  prompt: string,
+  env: Record<string, string>,
+  models: string[]
+): Promise<void> {
+  const chainStartedAt = Date.now();
+  for (let i = 0; i < models.length; i++) {
+    if (run.status === 'stopped') {
+      run.e2eLatencyMs = Date.now() - chainStartedAt;
+      return;
+    }
+    const model = models[i];
+    if (i > 0) {
+      pushLog(run, `降級到 ${model}（第 ${i} 層）`);
+    }
+    await runHttpAttempt(run, prompt, env, model);
+    run.e2eLatencyMs = Date.now() - chainStartedAt;
+    if (!run.errorType && run.resultText) {
+      run.effectiveModel = model;
+      run.modelSource = i === 0 ? 'requested' : `fallback-http:${i}`;
+      run.retryCount = i;
+      pushLog(run, i === 0 ? 'HTTP primary 成功' : `HTTP 降級成功（第 ${i} 層 / ${model}）`);
+      return;
+    }
+    run.retryCount = i + 1;
   }
-  if (provider === 'codex') {
-    return runOpenAiCompatFallback(
+  pushLog(run, 'HTTP 降級鏈已耗盡');
+}
+
+/**
+ * Single CLI attempt. Spawns the configured binary for `model`, streams stdout/stderr to
+ * `run.logs`, and resolves once the process closes. Returns whether this attempt yielded
+ * usable model output so the chain can decide to move on.
+ */
+async function runCliAttempt(
+  run: ActiveRun,
+  provider: AdapterProvider,
+  prompt: string,
+  tempFilePath: string | undefined,
+  env: Record<string, string>,
+  model: string
+): Promise<{ success: boolean; derivedText: string; signal: NodeJS.Signals | null }> {
+  const cli = getCommand(provider, prompt, tempFilePath, model);
+  const commandPreview = [cli.command, ...cli.args].join(' ');
+  run.command = commandPreview;
+  pushLog(run, `CLI 啟動：${commandPreview}`);
+  const attemptStartIdx = run.logs.length;
+  return new Promise((resolve) => {
+    const child = spawn(cli.command, cli.args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        ...env,
+      },
+    });
+    run.process = child;
+    child.stdout.on('data', (chunk: Buffer | string) => {
+      String(chunk)
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .forEach((line) => pushLog(run, line));
+    });
+    child.stderr.on('data', (chunk: Buffer | string) => {
+      String(chunk)
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .forEach((line) => pushLog(run, `[stderr] ${line}`));
+    });
+    child.on('error', (err) => {
+      pushLog(run, `程序錯誤：${err.message}`);
+      resolve({ success: false, derivedText: '', signal: null });
+    });
+    child.on('close', (code, signal) => {
+      pushLog(run, `程序已結束 (code=${code ?? 'null'}, signal=${signal ?? 'null'})`);
+      const attemptLogs = run.logs.slice(attemptStartIdx);
+      const failed = shouldUseApiFallback(provider, code, signal, attemptLogs);
+      const derivedText = deriveResultFromLogs(attemptLogs);
+      const success = !failed && Boolean(derivedText);
+      resolve({ success, derivedText, signal });
+    });
+  });
+}
+
+/**
+ * Run CLI attempts down the fallback chain. Each attempt spawns the same binary with the
+ * next model in the chain — no cross-path HTTP fallback.
+ */
+async function runCliChain(
+  run: ActiveRun,
+  provider: AdapterProvider,
+  prompt: string,
+  tempFilePath: string | undefined,
+  env: Record<string, string>,
+  models: string[]
+): Promise<void> {
+  const chainStartedAt = Date.now();
+  for (let i = 0; i < models.length; i++) {
+    if (run.status === 'stopped') {
+      run.e2eLatencyMs = Date.now() - chainStartedAt;
+      return;
+    }
+    const model = models[i];
+    if (i > 0) {
+      pushLog(run, `降級到 ${model}（第 ${i} 層）`);
+    }
+    const { success, derivedText, signal } = await runCliAttempt(
+      run,
+      provider,
       prompt,
-      'https://api.openai.com/v1/chat/completions',
-      fallbackModel || 'gpt-4o-mini',
-      env.OPENAI_API_KEY
+      tempFilePath,
+      env,
+      model,
     );
+    run.e2eLatencyMs = Date.now() - chainStartedAt;
+    // User-initiated stop: bail out, don't advance chain.
+    if (signal === 'SIGTERM' || signal === 'SIGKILL' || signal === 'SIGINT') {
+      return;
+    }
+    if (success) {
+      run.effectiveModel = model;
+      run.modelSource = i === 0 ? 'requested' : `fallback-cli:${i}`;
+      run.resultText = derivedText;
+      run.retryCount = i;
+      pushLog(run, i === 0 ? 'CLI primary 成功' : `CLI 降級成功（第 ${i} 層 / ${model}）`);
+      return;
+    }
+    run.retryCount = i + 1;
   }
-  if (provider === 'kilo' || provider === 'opencode') {
-    return runOpenAiCompatFallback(
-      prompt,
-      'https://openrouter.ai/api/v1/chat/completions',
-      fallbackModel || 'openai/gpt-4o-mini',
-      env.OPENROUTER_API_KEY
-    );
-  }
-  return '不支援的 provider fallback。';
+  pushLog(run, 'CLI 降級鏈已耗盡');
 }
 
 async function loadUserApiKeyEnv(userId: string): Promise<{
@@ -374,53 +546,6 @@ async function loadUserApiKeyEnv(userId: string): Promise<{
   return { env, sourceByEnvKey, availableModelsByProvider };
 }
 
-function resolveFallbackModel(
-  provider: AdapterProvider,
-  requestedModel: string,
-  availableModelsByProvider: Partial<Record<AIProvider, string[]>>
-): { model: string; source: 'requested' | 'validated-cache' | 'default' } {
-  const mapping: Record<AdapterProvider, { targetProvider: AIProvider; defaultModel: string }> = {
-    claude: { targetProvider: 'anthropic', defaultModel: 'claude-sonnet-4-20250514' },
-    gemini: { targetProvider: 'gemini', defaultModel: 'gemini-2.0-flash' },
-    codex: { targetProvider: 'openai', defaultModel: 'gpt-4o-mini' },
-    kilo: { targetProvider: 'openrouter', defaultModel: 'openrouter/auto' },
-    opencode: { targetProvider: 'openrouter', defaultModel: 'openrouter/auto' },
-  };
-  const target = mapping[provider];
-  const available = availableModelsByProvider[target.targetProvider] ?? [];
-  const req = requestedModel.toLowerCase();
-  if (requestedModel && available.includes(requestedModel)) {
-    return { model: requestedModel, source: 'requested' };
-  }
-  // For OpenRouter-backed adapters, preserve model-family intent first.
-  if ((provider === 'kilo' || provider === 'opencode') && req) {
-    const familyHints: Array<{ family: string; aliases: string[] }> = [
-      { family: 'kimi', aliases: ['kimi', 'moonshot'] },
-      { family: 'glm', aliases: ['glm', 'zhipu'] },
-      { family: 'minimax', aliases: ['minimax'] },
-      { family: 'qwen', aliases: ['qwen'] },
-      { family: 'gpt', aliases: ['gpt', 'openai'] },
-      { family: 'claude', aliases: ['claude', 'anthropic'] },
-      { family: 'gemini', aliases: ['gemini', 'google'] },
-    ];
-    const hint = familyHints.find((h) => h.aliases.some((a) => req.includes(a)));
-    if (hint) {
-      const matched = available.find((m) => {
-        const s = m.toLowerCase();
-        return hint.aliases.some((a) => s.includes(a));
-      });
-      if (matched) {
-        return { model: matched, source: 'validated-cache' };
-      }
-    }
-  }
-  const recommended = pickRecommendedModelByProvider(target.targetProvider, available);
-  if (recommended) {
-    return { model: recommended, source: 'validated-cache' };
-  }
-  return { model: target.defaultModel, source: 'default' };
-}
-
 function preflightStrictModelCheck(
   provider: AdapterProvider,
   requestedModel: string,
@@ -464,6 +589,7 @@ export async function POST(request: NextRequest) {
   const form = await request.formData();
   const adapterId = String(form.get('adapterId') || '').trim();
   const provider = String(form.get('provider') || '').trim() as AdapterProvider;
+  const mode = String(form.get('mode') || 'cli').trim() === 'http' ? 'http' : 'cli';
   const requestedModel = String(form.get('model') || '').trim();
   const prompt = String(form.get('prompt') || '').trim();
   const file = form.get('file');
@@ -482,40 +608,44 @@ export async function POST(request: NextRequest) {
 
   const { tempDir, tempFilePath } = await writeTempFileIfNeeded(file instanceof File ? file : null);
   const safePrompt = prompt || DEFAULT_ADAPTER_TEST_PROMPT;
-  const cli = getCommand(provider, safePrompt, tempFilePath, resolvedModel);
   const keyEnv = await loadUserApiKeyEnv(auth.userId);
   const preflight = preflightStrictModelCheck(provider, resolvedModel, keyEnv.availableModelsByProvider);
   if (!preflight.ok) {
     return NextResponse.json({ success: false, message: preflight.message }, { status: 400 });
   }
-  const fallbackResolved = resolveFallbackModel(provider, resolvedModel, keyEnv.availableModelsByProvider);
-  const child = spawn(cli.command, cli.args, {
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: {
-      ...process.env,
-      ...keyEnv.env,
-    },
-  });
-  const commandPreview = [cli.command, ...cli.args].join(' ');
+  /** Build the chain: primary first, then configured fallback slugs. Same-path only. */
+  const chainModels = resolvedModel
+    ? [resolvedModel, ...(adapter?.fallbackModels ?? [])]
+    : (adapter?.fallbackModels ?? []);
+  const previewCli = getCommand(provider, safePrompt, tempFilePath, resolvedModel);
+  const commandPreview = [previewCli.command, ...previewCli.args].join(' ');
   const run: ActiveRun = {
     userId: auth.userId,
     adapterId,
     provider,
+    mode,
     status: 'running',
-    process: child,
-    command: commandPreview,
+    process: null,
+    command: mode === 'http' ? `HTTP ${provider} ${resolvedModel}` : commandPreview,
     logs: [],
     resultText: '',
     requestedModel: resolvedModel,
     effectiveModel: resolvedModel,
     modelSource: 'requested',
+    ttftMs: null,
+    e2eLatencyMs: null,
+    tokensPerSec: null,
+    httpStatus: null,
+    retryCount: 0,
+    errorType: '',
+    successRateRecent: null,
     createdAt: Date.now(),
     updatedAt: Date.now(),
     tempDir,
     tempFilePath,
   };
   activeRuns.set(runKey, run);
-  pushLog(run, `啟動命令：${commandPreview}`);
+  pushLog(run, `啟動命令：${run.command}`);
   const sourceSummary = Object.entries(keyEnv.sourceByEnvKey)
     .map(([k, source]) => `${k}:${source}`)
     .join(', ');
@@ -527,43 +657,38 @@ export async function POST(request: NextRequest) {
   if (resolvedModel) {
     pushLog(run, `選定模型：${resolvedModel}`);
   }
-  pushLog(run, `Fallback 模型解析：${fallbackResolved.model}（${fallbackResolved.source}）`);
+  if (chainModels.length > 1) {
+    pushLog(run, `降級鏈（${mode}）：${chainModels.slice(1).join(' → ')}`);
+  }
   if (tempFilePath) pushLog(run, `掛載測試檔：${tempFilePath}`);
 
-  child.stdout.on('data', (chunk: Buffer | string) => {
-    String(chunk)
-      .split(/\r?\n/)
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .forEach((line) => pushLog(run, line));
-  });
-  child.stderr.on('data', (chunk: Buffer | string) => {
-    String(chunk)
-      .split(/\r?\n/)
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .forEach((line) => pushLog(run, `[stderr] ${line}`));
-  });
-  child.on('error', (err) => {
-    pushLog(run, `程序錯誤：${err.message}`);
+  if (chainModels.length === 0) {
     run.status = 'stopped';
-  });
-  child.on('close', async (code, signal) => {
-    pushLog(run, `程序已結束 (code=${code ?? 'null'}, signal=${signal ?? 'null'})`);
-    const shouldFallback = shouldUseApiFallback(provider, code, signal, run.logs);
-    if (shouldFallback) {
-      run.status = 'running';
-      pushLog(run, `偵測到 ${provider} CLI 失敗，切換到 API fallback...`);
-      const fallbackMsg = await runProviderFallback(provider, safePrompt, keyEnv.env, fallbackResolved.model);
-      pushLog(run, fallbackMsg);
-      run.resultText = stripAnsi(fallbackMsg.replace(/^.*fallback 成功：/, '').trim());
-      run.effectiveModel = fallbackResolved.model;
-      run.modelSource = `fallback:${fallbackResolved.source}`;
-    }
+    pushLog(run, '無可執行模型（primary 與 fallback 均為空）');
+    await cleanupTemp(run);
+    return NextResponse.json({
+      success: false,
+      message: '無可執行模型',
+      status: run.status,
+      logs: run.logs,
+      cursor: run.logs.length,
+    }, { status: 400 });
+  }
+
+  const chainPromise =
+    mode === 'http'
+      ? runHttpChain(run, safePrompt, keyEnv.env, chainModels)
+      : runCliChain(run, provider, safePrompt, tempFilePath, keyEnv.env, chainModels);
+
+  void chainPromise.finally(async () => {
     if (!run.resultText) {
       run.resultText = deriveResultFromLogs(run.logs);
     }
-    run.status = 'stopped';
+    const success = Boolean(run.resultText) && !run.errorType;
+    run.successRateRecent = pushRunHistory(runKey, success);
+    if (run.status !== 'stopped') {
+      run.status = 'stopped';
+    }
     await cleanupTemp(run);
   });
 
@@ -571,12 +696,19 @@ export async function POST(request: NextRequest) {
     success: true,
     status: run.status,
     command: run.command,
-    pid: child.pid ?? null,
+    pid: run.process?.pid ?? null,
     logs: run.logs,
     resultText: run.resultText,
     requestedModel: run.requestedModel,
     effectiveModel: run.effectiveModel,
     modelSource: run.modelSource,
+    ttftMs: run.ttftMs,
+    e2eLatencyMs: run.e2eLatencyMs,
+    tokensPerSec: run.tokensPerSec,
+    httpStatus: run.httpStatus,
+    retryCount: run.retryCount,
+    errorType: run.errorType,
+    successRateRecent: run.successRateRecent,
     cursor: run.logs.length,
   });
 }
@@ -592,9 +724,10 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ success: false, message: auth.message }, { status: auth.status });
   }
 
-  const body = await request.json() as { adapterId?: string; action?: 'pause' | 'resume' | 'stop' };
+  const body = await request.json() as { adapterId?: string; action?: 'pause' | 'resume' | 'stop'; mode?: 'cli' | 'http' };
   const adapterId = body.adapterId?.trim();
   const action = body.action;
+  const mode = body.mode === 'http' ? 'http' : 'cli';
   if (!adapterId || !action) {
     return NextResponse.json({ success: false, message: '缺少 adapterId 或 action' }, { status: 400 });
   }
@@ -604,20 +737,28 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ success: false, message: '找不到執行中的 adapter' }, { status: 404 });
   }
 
+  if (run.mode !== mode) {
+    return NextResponse.json({ success: false, message: 'run mode 不一致' }, { status: 409 });
+  }
+
+  if (run.mode === 'http' && action !== 'stop') {
+    return NextResponse.json({ success: false, message: 'HTTP 模式不支援 pause/resume' }, { status: 400 });
+  }
+
   if (action === 'pause') {
     if (run.status === 'running') {
-      run.process.kill('SIGSTOP');
+      run.process?.kill('SIGSTOP');
       run.status = 'paused';
       pushLog(run, '已暫停執行（SIGSTOP）');
     }
   } else if (action === 'resume') {
     if (run.status === 'paused') {
-      run.process.kill('SIGCONT');
+      run.process?.kill('SIGCONT');
       run.status = 'running';
       pushLog(run, '已恢復執行（SIGCONT）');
     }
   } else if (action === 'stop') {
-    run.process.kill('SIGTERM');
+    run.process?.kill('SIGTERM');
     run.status = 'stopped';
     pushLog(run, '已發送停止訊號（SIGTERM）');
   }
@@ -626,12 +767,19 @@ export async function PATCH(request: NextRequest) {
     success: true,
     status: run.status,
     command: run.command,
-    pid: run.process.pid ?? null,
+    pid: run.process?.pid ?? null,
     logs: run.logs,
     resultText: run.resultText,
     requestedModel: run.requestedModel,
     effectiveModel: run.effectiveModel,
     modelSource: run.modelSource,
+    ttftMs: run.ttftMs,
+    e2eLatencyMs: run.e2eLatencyMs,
+    tokensPerSec: run.tokensPerSec,
+    httpStatus: run.httpStatus,
+    retryCount: run.retryCount,
+    errorType: run.errorType,
+    successRateRecent: run.successRateRecent,
     cursor: run.logs.length,
   });
 }
@@ -648,6 +796,7 @@ export async function GET(request: NextRequest) {
   }
 
   const adapterId = request.nextUrl.searchParams.get('adapterId')?.trim();
+  const mode = request.nextUrl.searchParams.get('mode') === 'http' ? 'http' : 'cli';
   const cursorRaw = request.nextUrl.searchParams.get('cursor');
   const cursor = Number.isFinite(Number(cursorRaw)) ? Number(cursorRaw) : 0;
   if (!adapterId) {
@@ -666,6 +815,34 @@ export async function GET(request: NextRequest) {
       requestedModel: '',
       effectiveModel: '',
       modelSource: '',
+      ttftMs: null,
+      e2eLatencyMs: null,
+      tokensPerSec: null,
+      httpStatus: null,
+      retryCount: 0,
+      errorType: '',
+      successRateRecent: null,
+      cursor: 0,
+    });
+  }
+  if (run.mode !== mode) {
+    return NextResponse.json({
+      success: true,
+      status: 'idle' satisfies RunStatus,
+      command: '',
+      pid: null,
+      logs: [],
+      resultText: '',
+      requestedModel: '',
+      effectiveModel: '',
+      modelSource: '',
+      ttftMs: null,
+      e2eLatencyMs: null,
+      tokensPerSec: null,
+      httpStatus: null,
+      retryCount: 0,
+      errorType: '',
+      successRateRecent: null,
       cursor: 0,
     });
   }
@@ -674,12 +851,19 @@ export async function GET(request: NextRequest) {
     success: true,
     status: run.status,
     command: run.command,
-    pid: run.process.pid ?? null,
+    pid: run.process?.pid ?? null,
     logs: run.logs.slice(Math.max(0, cursor)),
     resultText: run.resultText,
     requestedModel: run.requestedModel,
     effectiveModel: run.effectiveModel,
     modelSource: run.modelSource,
+    ttftMs: run.ttftMs,
+    e2eLatencyMs: run.e2eLatencyMs,
+    tokensPerSec: run.tokensPerSec,
+    httpStatus: run.httpStatus,
+    retryCount: run.retryCount,
+    errorType: run.errorType,
+    successRateRecent: run.successRateRecent,
     cursor: run.logs.length,
   });
 }

--- a/apps/superadmin/app/api/ai-settings/models/test/route.ts
+++ b/apps/superadmin/app/api/ai-settings/models/test/route.ts
@@ -21,6 +21,7 @@ import { requireSuperadmin } from '@/lib/auth/require-superadmin';
 import {
   KILO_GATEWAY_BASE,
   OPENCODE_ZEN_CHAT_COMPLETIONS_URL,
+  openCodeZenChatModelId,
 } from '@/lib/ai-key-validation/kilo-opencode-zen';
 
 const DEFAULT_TEST_PROMPT = '請用一句話回覆：你好，我是{你的模型名稱與型號}，可以正常接收並回應。';
@@ -540,7 +541,7 @@ async function testOpenCode(
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
       body: JSON.stringify({
-        model: modelId,
+        model: openCodeZenChatModelId(modelId),
         messages: [{ role: 'user', content }],
         max_tokens,
       }),

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/__tests__/adapter-evaluation.test.ts
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/__tests__/adapter-evaluation.test.ts
@@ -136,6 +136,61 @@ describe('evaluateAdapterRun', () => {
     expect(isExplicitEmptyOrErrorOutcome('這是一段正常的模型回答內容')).toBe(false);
   });
 
+  it('isExplicitEmptyOrErrorOutcome matches HTTP adapter log lines from route.ts', () => {
+    expect(isExplicitEmptyOrErrorOutcome('HTTP 失敗：This operation was aborted')).toBe(true);
+    expect(isExplicitEmptyOrErrorOutcome('HTTP 回應成功，但無輸出')).toBe(true);
+  });
+
+  it('fails when errorType is set (HTTP empty_output)', () => {
+    expect(
+      evaluateAdapterRun({
+        requestedModel: 'gpt-5.3-codex',
+        effectiveModel: 'gpt-5.3-codex',
+        renderedOutput: '',
+        outputLines: ['[06:47:35] 啟動命令：HTTP codex gpt-5.3-codex', '[06:47:35] HTTP 回應成功，但無輸出'],
+        errorType: 'empty_output',
+        httpStatus: 200,
+      }),
+    ).toEqual({
+      level: 'fail',
+      message: '不及格（HTTP 無可讀模型輸出）',
+    });
+  });
+
+  it('fails when errorType is runtime_error (e.g. abort)', () => {
+    expect(evaluateAdapterRun({
+      requestedModel: 'gpt-5.4-pro',
+      effectiveModel: 'gpt-5.4-pro',
+      renderedOutput: '',
+      outputLines: ['x'],
+      errorType: 'runtime_error',
+    }).level).toBe('fail');
+  });
+
+  it('fails when httpStatus is non-2xx', () => {
+    expect(
+      evaluateAdapterRun({
+        requestedModel: 'gpt-4.1',
+        effectiveModel: 'gpt-4.1',
+        renderedOutput: 'ignored',
+        outputLines: ['ok'],
+        errorType: '',
+        httpStatus: 401,
+      }).message,
+    ).toBe('不及格（HTTP 401）');
+  });
+
+  it('fails when render is HTTP success-but-empty line without errorType (log-derived)', () => {
+    expect(
+      evaluateAdapterRun({
+        requestedModel: 'gpt-5.3-codex',
+        effectiveModel: 'gpt-5.3-codex',
+        renderedOutput: 'HTTP 回應成功，但無輸出',
+        outputLines: ['[log] enough characters here to pass raw length'],
+      }).level,
+    ).toBe('fail');
+  });
+
   it('passes when render is short but raw log has enough text (deriveResultFromLogs edge case)', () => {
     const longRaw = '這是一段足夠長的 CLI 輸出內容用於測試';
     const result = evaluateAdapterRun({
@@ -146,6 +201,23 @@ describe('evaluateAdapterRun', () => {
     });
 
     expect(result.level).toBe('pass');
+  });
+
+  it('fails when raw is only adapter bookkeeping (no model reply)', () => {
+    const result = evaluateAdapterRun({
+      requestedModel: 'openrouter/qwen/qwen3.6-plus',
+      effectiveModel: 'openrouter/qwen/qwen3.6-plus',
+      renderedOutput: '',
+      outputLines: [
+        '[07:42:40] 啟動命令：opencode -m openrouter/qwen/qwen3.6-plus run 你好',
+        '[07:42:40] API Key 來源：ANTHROPIC_API_KEY:supabase, OPENROUTER_API_KEY:supabase',
+        '[07:42:40] 選定模型：openrouter/qwen/qwen3.6-plus',
+        '[07:42:40] Fallback 模型解析：openrouter/qwen/qwen3.6-plus（requested）',
+      ],
+    });
+
+    expect(result.level).toBe('fail');
+    expect(result.message).toMatch(/render 與 raw 皆過短或空白/);
   });
 
   it('still warns when different model versions (e.g. minimax m2.6 vs m2.7)', () => {
@@ -176,6 +248,17 @@ describe('evaluateAdapterRun', () => {
     expect(result.message).toMatch(/m2\.1/i);
   });
 
+  it('warns when minimax m2.5 is requested but reply self-reports M2.1 (OpenRouter upstream)', () => {
+    const result = evaluateAdapterRun({
+      requestedModel: 'openrouter/minimax/minimax-m2.5',
+      effectiveModel: 'openrouter/minimax/minimax-m2.5',
+      renderedOutput: '你好！我是 **MiniMax-M2.1**，由 **MiniMax** 公司构建的AI助手。',
+      outputLines: ['ok'],
+    });
+    expect(result.level).toBe('warning');
+    expect(result.message).toMatch(/minimax-m2\.5/);
+  });
+
   it('passes when self-reported version matches requested (m2.5 == m2.5, real OpenCode case)', () => {
     const result = evaluateAdapterRun({
       requestedModel: 'openrouter/minimax/minimax-m2.5',
@@ -196,6 +279,29 @@ describe('evaluateAdapterRun', () => {
     });
 
     expect(result.level).toBe('pass');
+  });
+
+  it('warns when gpt-5 is requested but reply only cites GPT-4 line (marketing copy)', () => {
+    const result = evaluateAdapterRun({
+      requestedModel: 'gpt-5.3-codex',
+      effectiveModel: 'gpt-5.3-codex',
+      renderedOutput:
+        '我是 OpenAI 的模型，透過 API 提供服務。我是「ChatGPT (GPT-4 系列能力)」的助理。',
+      outputLines: ['ok'],
+    });
+    expect(result.level).toBe('warning');
+    expect(result.message).toMatch(/gpt-5/);
+  });
+
+  it('still passes gpt-5 request when reply also mentions gpt-5', () => {
+    expect(
+      evaluateAdapterRun({
+        requestedModel: 'gpt-5.3-codex',
+        effectiveModel: 'gpt-5.3-codex',
+        renderedOutput: '我是基於 gpt-5.3-codex 的助理，與舊版 GPT-4 不同。',
+        outputLines: ['ok'],
+      }).level,
+    ).toBe('pass');
   });
 
   it('passes when self-report cites a different family entirely (conservative — could be analogy)', () => {

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/__tests__/settings-persist.test.tsx
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/__tests__/settings-persist.test.tsx
@@ -96,6 +96,11 @@ jest.mock('@/lib/parse-env-keys', () => ({
   SUPPORTED_AI_ENV_KEY_NAMES: [],
 }));
 
+jest.mock('@/components/ai-settings/PromptManagerModal', () => ({
+  PROMPT_LOAD_MESSAGE_TYPE: 'PROMPT_LOAD',
+  PromptManagerModal: () => null,
+}));
+
 // ── Import page after mocks ────────────────────────────────────────────────
 import AIServiceSettingsPage from '../page';
 

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/adapter-config-columns.tsx
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/adapter-config-columns.tsx
@@ -32,6 +32,13 @@ export type AdapterConfigDraftCell = {
   requestedModel: string;
   effectiveModel: string;
   modelSource: string;
+  ttftMs?: number | null;
+  e2eLatencyMs?: number | null;
+  tokensPerSec?: number | null;
+  httpStatus?: number | null;
+  retryCount?: number;
+  errorType?: string;
+  successRateRecent?: number | null;
 };
 
 export type AdapterPromptOptionCell = { id: string; label: string; content: string };
@@ -55,6 +62,7 @@ export interface CreateAdapterConfigColumnsDeps {
     adapterId: string,
     action: 'pause' | 'resume' | 'stop',
   ) => void | Promise<void>;
+  showHttpMetrics?: boolean;
 }
 
 const col = createColumnHelper<AdapterConfigTableRow>();
@@ -111,9 +119,10 @@ export function createAdapterConfigColumns(
     setAdapterConfigDrafts,
     startAdapterRun,
     controlAdapterRun,
+    showHttpMetrics = false,
   } = deps;
 
-  return [
+  const columns: ColumnDef<AdapterConfigTableRow, unknown>[] = [
     col.accessor('serialNo', {
       id: 'col-serial',
       meta: meta('No.', '編號'),
@@ -341,6 +350,31 @@ export function createAdapterConfigColumns(
     }) as ColumnDef<AdapterConfigTableRow, unknown>,
 
     col.display({
+      id: 'col-fallback-chain',
+      meta: meta('Fallback chain', '降級鏈'),
+      enableSorting: false,
+      cell: ({ row }) => {
+        const { item } = row.original;
+        const chain = item.fallbackModels ?? [];
+        if (chain.length === 0) {
+          return <span className="text-[11px] text-text-muted">—</span>;
+        }
+        return (
+          <ol
+            className="list-decimal space-y-0.5 pl-4 font-mono text-[11px] text-text-secondary"
+            title="primary 失敗時依序降級；CLI/HTTP 各自只走同一路徑"
+          >
+            {chain.map((m) => (
+              <li key={m} className="break-all">
+                {m}
+              </li>
+            ))}
+          </ol>
+        );
+      },
+    }) as ColumnDef<AdapterConfigTableRow, unknown>,
+
+    col.display({
       id: 'col-raw-output',
       meta: meta('Raw output', '輸出 output'),
       enableSorting: false,
@@ -424,6 +458,8 @@ export function createAdapterConfigColumns(
           effectiveModel: effective,
           renderedOutput: draft.renderedOutput,
           outputLines: draft.outputLines,
+          errorType: draft.errorType,
+          httpStatus: draft.httpStatus,
         });
         const badgeClass = {
           pass: 'border-emerald-300 bg-emerald-100 text-emerald-800',
@@ -443,4 +479,72 @@ export function createAdapterConfigColumns(
       },
     }) as ColumnDef<AdapterConfigTableRow, unknown>,
   ];
+
+  if (showHttpMetrics) {
+    columns.push(
+      col.display({
+        id: 'col-ttft',
+        meta: meta('TTFT (ms)', '首 token 延遲(ms)'),
+        enableSorting: false,
+        cell: ({ row }) => {
+          const ttft = row.original.draft.ttftMs;
+          return <span className="font-mono text-xs text-text-secondary">{ttft != null ? Math.round(ttft) : '—'}</span>;
+        },
+      }) as ColumnDef<AdapterConfigTableRow, unknown>,
+      col.display({
+        id: 'col-e2e',
+        meta: meta('E2E (ms)', '完成時間(ms)'),
+        enableSorting: false,
+        cell: ({ row }) => {
+          const e2e = row.original.draft.e2eLatencyMs;
+          return <span className="font-mono text-xs text-text-secondary">{e2e != null ? Math.round(e2e) : '—'}</span>;
+        },
+      }) as ColumnDef<AdapterConfigTableRow, unknown>,
+      col.display({
+        id: 'col-tps',
+        meta: meta('Throughput', '吞吐(tokens/s)'),
+        enableSorting: false,
+        cell: ({ row }) => {
+          const tps = row.original.draft.tokensPerSec;
+          return <span className="font-mono text-xs text-text-secondary">{tps != null ? tps.toFixed(2) : '—'}</span>;
+        },
+      }) as ColumnDef<AdapterConfigTableRow, unknown>,
+      col.display({
+        id: 'col-http-status',
+        meta: meta('HTTP', 'HTTP 狀態碼'),
+        enableSorting: false,
+        cell: ({ row }) => {
+          const status = row.original.draft.httpStatus;
+          return <span className="font-mono text-xs text-text-secondary">{status ?? '—'}</span>;
+        },
+      }) as ColumnDef<AdapterConfigTableRow, unknown>,
+      col.display({
+        id: 'col-retry',
+        meta: meta('Retry', '重試次數'),
+        enableSorting: false,
+        cell: ({ row }) => (
+          <span className="font-mono text-xs text-text-secondary">{row.original.draft.retryCount ?? 0}</span>
+        ),
+      }) as ColumnDef<AdapterConfigTableRow, unknown>,
+      col.display({
+        id: 'col-error-type',
+        meta: meta('Error Type', '錯誤類型'),
+        enableSorting: false,
+        cell: ({ row }) => (
+          <span className="font-mono text-[11px] text-text-secondary">{row.original.draft.errorType || '—'}</span>
+        ),
+      }) as ColumnDef<AdapterConfigTableRow, unknown>,
+      col.display({
+        id: 'col-success-rate',
+        meta: meta('Success(N)', '成功率(最近N次)'),
+        enableSorting: false,
+        cell: ({ row }) => {
+          const rate = row.original.draft.successRateRecent;
+          return <span className="font-mono text-xs text-text-secondary">{rate != null ? `${Math.round(rate * 100)}%` : '—'}</span>;
+        },
+      }) as ColumnDef<AdapterConfigTableRow, unknown>,
+    );
+  }
+
+  return columns;
 }

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/adapter-evaluation.ts
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/adapter-evaluation.ts
@@ -1,3 +1,5 @@
+import { isAdapterRunMetaLine } from '@/lib/adapter-runs/adapter-run-meta-lines';
+
 export type AdapterEvaluationLevel = 'pass' | 'warning' | 'fail' | 'pending';
 
 export interface AdapterEvaluationResult {
@@ -10,6 +12,10 @@ export interface EvaluateAdapterRunInput {
   effectiveModel: string;
   renderedOutput: string;
   outputLines: string[];
+  /** 來自 adapter-runs HTTP 模式 classifyHttpError；非空表示本次請求未成功取得模型輸出 */
+  errorType?: string;
+  /** HTTP 回應狀態碼；與 errorType 一併用於判定 */
+  httpStatus?: number | null;
 }
 
 const MIN_MEANINGFUL_OUTPUT_CHARS = 8;
@@ -39,13 +45,16 @@ function hasRenderableOutput(renderedOutput: string): boolean {
 }
 
 function hasRawOutput(outputLines: string[]): boolean {
-  return outputLines.some((line) => meaningfulCharCount(line) > 0);
+  return outputLines.some(
+    (line) => !isAdapterRunMetaLine(line) && meaningfulCharCount(line) > 0,
+  );
 }
 
 /** CLI 有完整 log，但 deriveResultFromLogs 只取最後一行時，render 可能過短；此時仍以 raw 整段為準。 */
 function hasMeaningfulAdapterOutput(renderedOutput: string, outputLines: string[]): boolean {
   if (hasRenderableOutput(renderedOutput)) return true;
-  const joined = outputLines.join('\n');
+  const substantive = outputLines.filter((line) => !isAdapterRunMetaLine(line));
+  const joined = substantive.join('\n');
   return meaningfulCharCount(joined) >= MIN_MEANINGFUL_OUTPUT_CHARS;
 }
 
@@ -67,14 +76,60 @@ export function isExplicitEmptyOrErrorOutcome(text: string): boolean {
   return (
     /無文字輸出/.test(t) ||
     /無輸出[：:]/.test(t) ||
+    /成功，但無輸出/.test(t) ||
     /未取得可讀文字/.test(t) ||
     /無法執行\s*(API\s*)?fallback/i.test(t) ||
     /fallback\s*失敗/i.test(t) ||
     /無可用\s+\w+\s*API/i.test(t) ||
     /缺少\s+API\s*key/i.test(t) ||
     /不支援的\s+provider\s+fallback/i.test(t) ||
-    /no text output/i.test(t)
+    /no text output/i.test(t) ||
+    /HTTP\s*失敗/i.test(t) ||
+    /operation was aborted/i.test(t)
   );
+}
+
+function humanizeAdapterErrorType(errorType: string): string {
+  switch (errorType) {
+    case 'empty_output':
+      return 'HTTP 無可讀模型輸出';
+    case 'timeout':
+      return '請求逾時或逾時中止';
+    case '429':
+      return '速率限制（429）';
+    case '5xx':
+      return '伺服器錯誤（5xx）';
+    case '4xx':
+      return '請求錯誤（4xx）';
+    case 'schema':
+      return '回應格式異常';
+    case 'runtime_error':
+      return '執行錯誤';
+    default:
+      return errorType;
+  }
+}
+
+function httpStatusIndicatesFailure(status: number): boolean {
+  return status < 200 || status > 299;
+}
+
+/**
+ * 請求 id 為 gpt-5 系，但模型回答只自稱 GPT-4 系列（常見於 OpenAI 行銷用語／舊版文案）。
+ * 與 {@link compareSelfReportToRequested} 的「缺版本則放行」不同，這裡顯式提醒使用者勿把「及格」當成實際代號一致。
+ */
+function isGpt5RequestedButReplyClaimsGpt4Line(requestedModel: string, renderedOutput: string): boolean {
+  const req = requestedModel.trim();
+  if (!/^gpt-5/i.test(req)) return false;
+  const t = renderedOutput;
+  if (/\bgpt-5|GPT-5|gpt5\b/i.test(t)) return false;
+  return /GPT[-\s]?4|gpt[-\s]?4/i.test(t);
+}
+
+/** OpenRouter 對 minimax 路由有時仍回 M2.1 自介；請求 m2.5 時不應當成「設定錯誤」硬判不及格。 */
+function isMinimaxM25RequestButM21SelfReport(requestedModel: string, renderedOutput: string): boolean {
+  if (!/minimax-m2\.5|minimax\/minimax-m2\.5/i.test(requestedModel)) return false;
+  return /MiniMax-M2\.1|minimax-m2\.1|\bM2\.1\b/i.test(renderedOutput);
 }
 
 function hasNoActualModelReply(renderedOutput: string, outputLines: string[]): boolean {
@@ -196,6 +251,20 @@ export function evaluateAdapterRun(input: EvaluateAdapterRunInput): AdapterEvalu
   const requestedModel = input.requestedModel.trim();
   const effectiveModel = input.effectiveModel.trim();
   const renderedOutput = input.renderedOutput.trim();
+  const errType = (input.errorType ?? '').trim();
+  if (errType) {
+    return {
+      level: 'fail',
+      message: `不及格（${humanizeAdapterErrorType(errType)}）`,
+    };
+  }
+  const httpSt = input.httpStatus;
+  if (httpSt != null && httpStatusIndicatesFailure(httpSt)) {
+    return {
+      level: 'fail',
+      message: `不及格（HTTP ${httpSt}）`,
+    };
+  }
   const modelMatched = !!requestedModel && modelsMatchForEvaluation(requestedModel, effectiveModel);
   const rawOk = hasRawOutput(input.outputLines);
   const outputMeaningfulEnough = hasMeaningfulAdapterOutput(renderedOutput, input.outputLines);
@@ -227,9 +296,24 @@ export function evaluateAdapterRun(input: EvaluateAdapterRunInput): AdapterEvalu
   const selfReported = parseSelfReportedModel(renderedOutput);
   const comparison = compareSelfReportToRequested(selfReported, requestedModel);
   if (comparison === 'version-mismatch') {
+    if (isMinimaxM25RequestButM21SelfReport(requestedModel, renderedOutput)) {
+      return {
+        level: 'warning',
+        message:
+          '注意：請求為 minimax-m2.5，但自介為 M2.1；OpenRouter 對 minimax 路由有時仍會落到 M2.1（與 M2.7→M2.1 類似）。此非設定表錯誤。',
+      };
+    }
     return {
       level: 'fail',
       message: `不及格（模型自報為 ${selfReported.raw ?? selfReported.family}，與請求的 ${requestedModel} 不一致，provider 可能未誠實回傳實際版本）`,
+    };
+  }
+
+  if (isGpt5RequestedButReplyClaimsGpt4Line(requestedModel, renderedOutput)) {
+    return {
+      level: 'warning',
+      message:
+        '注意：請求為 gpt-5 系，但回覆文字自稱 GPT-4 系列；可能是官方顯示用語，實際後端仍為你請求的模型，請勿僅依自介判斷代號。',
     };
   }
 

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/model-router-columns.tsx
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/model-router-columns.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { createColumnHelper, type ColumnDef } from '@tanstack/react-table';
+
+export type ModelRouterRow = {
+  id: string;
+  scenario: string;
+  owner: string;
+  primaryModel: string;
+  fallbackChain: string;
+  triggerRule: string;
+  status: 'planned' | 'testing' | 'ready';
+  notes: string;
+};
+
+const col = createColumnHelper<ModelRouterRow>();
+
+export const MODEL_ROUTER_ROWS: ModelRouterRow[] = [
+  {
+    id: 'MR-001',
+    scenario: '謄本解析 AI 助手',
+    owner: 'OCR / VLM',
+    primaryModel: 'gemini-2.5-pro',
+    fallbackChain: 'claude-3-7-sonnet -> gpt-4.1',
+    triggerRule: 'OCR 信心值 < 0.80 或 JSON schema 驗證失敗',
+    status: 'testing',
+    notes: '第一輪失敗時自動補跑 fallback，保留三次結果供比對。',
+  },
+  {
+    id: 'MR-002',
+    scenario: '合約條款摘要',
+    owner: 'Contract Assistant',
+    primaryModel: 'claude-3-7-sonnet',
+    fallbackChain: 'gpt-4.1 -> gemini-2.0-flash',
+    triggerRule: '回覆逾時 > 20s 或 token 超限',
+    status: 'ready',
+    notes: '高精度優先，fallback 時降低 max_tokens 控制成本。',
+  },
+  {
+    id: 'MR-003',
+    scenario: '房源文案生成',
+    owner: 'Listing Content',
+    primaryModel: 'gpt-4.1-mini',
+    fallbackChain: 'claude-3-5-haiku',
+    triggerRule: '429/5xx 連續兩次或內容違反字數規範',
+    status: 'ready',
+    notes: '採低成本模型為主，並加上語氣模板重試。',
+  },
+  {
+    id: 'MR-004',
+    scenario: '客服 FAQ 助手',
+    owner: 'Web Assistant',
+    primaryModel: 'claude-3-5-haiku',
+    fallbackChain: 'gpt-4.1-mini',
+    triggerRule: '首 token latency > 3s 或安全檢查未過',
+    status: 'testing',
+    notes: 'fallback 前先嘗試同模型降溫度重試一次。',
+  },
+  {
+    id: 'MR-005',
+    scenario: '批次資料標註（夜間）',
+    owner: 'Ops Batch',
+    primaryModel: 'gemini-2.0-flash',
+    fallbackChain: 'gpt-4.1-mini -> claude-3-5-haiku',
+    triggerRule: '工作佇列積壓 > 500 或每分鐘錯誤率 > 5%',
+    status: 'planned',
+    notes: '批次模式偏吞吐量，fallback 依速度排序。',
+  },
+];
+
+const STATUS_BADGE: Record<ModelRouterRow['status'], { label: string; className: string }> = {
+  planned: {
+    label: 'Planned',
+    className: 'border-slate-300 bg-slate-100 text-slate-700',
+  },
+  testing: {
+    label: 'Testing',
+    className: 'border-amber-300 bg-amber-100 text-amber-800',
+  },
+  ready: {
+    label: 'Ready',
+    className: 'border-emerald-300 bg-emerald-100 text-emerald-800',
+  },
+};
+
+export const MODEL_ROUTER_TABLE_INITIAL_WIDTHS = [8, 14, 12, 14, 16, 18, 8, 10];
+export const MODEL_ROUTER_TABLE_MIN_WIDTH_PX = 1600;
+
+export function createModelRouterColumns(): ColumnDef<ModelRouterRow, unknown>[] {
+  return [
+    col.accessor('id', {
+      id: 'col-id',
+      header: 'ID',
+      meta: { headerEn: 'ID', headerZh: '編號' },
+      cell: ({ getValue }) => (
+        <span className="font-mono text-xs font-semibold text-text-secondary">{getValue()}</span>
+      ),
+    }) as ColumnDef<ModelRouterRow, unknown>,
+    col.accessor('scenario', {
+      id: 'col-scenario',
+      header: 'Scenario',
+      meta: { headerEn: 'Scenario', headerZh: '場景 / 模組' },
+      cell: ({ getValue }) => (
+        <p className="text-xs font-medium text-text-primary">{getValue()}</p>
+      ),
+    }) as ColumnDef<ModelRouterRow, unknown>,
+    col.accessor('owner', {
+      id: 'col-owner',
+      header: 'Owner',
+      meta: { headerEn: 'Owner', headerZh: '負責模組' },
+      cell: ({ getValue }) => <p className="text-xs text-text-secondary">{getValue()}</p>,
+    }) as ColumnDef<ModelRouterRow, unknown>,
+    col.accessor('primaryModel', {
+      id: 'col-primary',
+      header: 'Primary Model',
+      meta: { headerEn: 'Primary Model', headerZh: '主模型' },
+      cell: ({ getValue }) => (
+        <p className="font-mono text-[11px] text-text-primary break-all">{getValue()}</p>
+      ),
+    }) as ColumnDef<ModelRouterRow, unknown>,
+    col.accessor('fallbackChain', {
+      id: 'col-fallback',
+      header: 'Fallback Chain',
+      meta: { headerEn: 'Fallback Chain', headerZh: 'Fallback 鏈' },
+      cell: ({ getValue }) => (
+        <p className="font-mono text-[11px] text-text-secondary break-all">{getValue()}</p>
+      ),
+    }) as ColumnDef<ModelRouterRow, unknown>,
+    col.accessor('triggerRule', {
+      id: 'col-trigger',
+      header: 'Trigger Rule',
+      meta: { headerEn: 'Trigger Rule', headerZh: '切換條件' },
+      cell: ({ getValue }) => <p className="text-xs text-text-secondary">{getValue()}</p>,
+    }) as ColumnDef<ModelRouterRow, unknown>,
+    col.accessor('status', {
+      id: 'col-status',
+      header: 'Status',
+      meta: { headerEn: 'Status', headerZh: '狀態' },
+      cell: ({ getValue }) => {
+        const badge = STATUS_BADGE[getValue()];
+        return (
+          <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${badge.className}`}>
+            {badge.label}
+          </span>
+        );
+      },
+    }) as ColumnDef<ModelRouterRow, unknown>,
+    col.accessor('notes', {
+      id: 'col-notes',
+      header: 'Notes',
+      meta: { headerEn: 'Notes', headerZh: '備註' },
+      cell: ({ getValue }) => <p className="text-xs text-text-muted">{getValue()}</p>,
+    }) as ColumnDef<ModelRouterRow, unknown>,
+  ];
+}

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/page.tsx
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/page.tsx
@@ -3,16 +3,29 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Key, FlaskConical, ScanText, BookMarked, Trophy, Bot,
-  Loader2, RefreshCw, Trash2, ShieldCheck, Upload, Download, Play, Pause, Square,
+  Loader2, RefreshCw, Trash2, ShieldCheck, Upload, Download, Play, Pause, Square, Route,
+  Eye, ExternalLink,
 } from 'lucide-react';
+import {
+  PromptManagerModal,
+  PROMPT_LOAD_MESSAGE_TYPE,
+} from '@/components/ai-settings/PromptManagerModal';
 
 import { BottomSheetTabs, type SheetTabDef } from '@/components/ui/BottomSheetTabs';
 import EnhancedTable from '@/components/ui/EnhancedTable';
 import {
   createAdapterConfigColumns,
   formatAdapterSerial,
+  type AdapterConfigDraftCell,
   type AdapterConfigTableRow,
 } from './adapter-config-columns';
+import {
+  createModelRouterColumns,
+  MODEL_ROUTER_ROWS,
+  MODEL_ROUTER_TABLE_INITIAL_WIDTHS,
+  MODEL_ROUTER_TABLE_MIN_WIDTH_PX,
+  type ModelRouterRow,
+} from './model-router-columns';
 import { readLocalStorage, writeLocalStorage } from '@/lib/utils/storage-state';
 import { DashboardLayout } from '@/components/dashboard';
 import { Button } from '@/components/ui/Button';
@@ -37,9 +50,24 @@ import { ADAPTER_CONFIG_ITEMS, DEFAULT_ADAPTER_TEST_PROMPT } from '@/lib/adapter
 import { evaluateAdapterRun } from './adapter-evaluation';
 
 
-type SettingsTab = 'keys' | 'llm-leaderboard' | 'adapter-config' | 'ocr';
+type SettingsTab =
+  | 'keys'
+  | 'llm-leaderboard'
+  | 'evaluations-global'
+  | 'adapter-config'
+  | 'http-adapter-config'
+  | 'model-router'
+  | 'ocr';
 
-const TAB_IDS: SettingsTab[] = ['keys', 'llm-leaderboard', 'adapter-config', 'ocr'];
+const TAB_IDS: SettingsTab[] = [
+  'keys',
+  'llm-leaderboard',
+  'evaluations-global',
+  'adapter-config',
+  'http-adapter-config',
+  'model-router',
+  'ocr',
+];
 
 const LS_GLOBAL_PROMPT = 'ai-settings:globalTestPrompt';
 const LS_SAVED_PROMPTS = 'ai-settings:savedPrompts';
@@ -158,10 +186,28 @@ const TABS: { id: SettingsTab; label: string; icon: React.ElementType; descripti
     description: 'Artificial Analysis LLM 排行榜（每日同步）',
   },
   {
+    id: 'evaluations-global',
+    label: 'AI 模型全域評測',
+    icon: FlaskConical,
+    description: '上傳測試檔、設定全域 Prompt，並對已選模型執行批次評測（與專案進度表相同風格之工作表版面）',
+  },
+  {
     id: 'adapter-config',
     label: 'Adapter調適與設定',
     icon: Bot,
     description: '設定 Adapter 的模型映射、調適策略與可用性',
+  },
+  {
+    id: 'http-adapter-config',
+    label: 'HTTP Adapter調適',
+    icon: Bot,
+    description: '透過 HTTP API 直接比較速度與穩定度（對照 CLI）',
+  },
+  {
+    id: 'model-router',
+    label: 'Model Router',
+    icon: Route,
+    description: '規劃各 AI 助手模型路由、切換條件與 fallback 策略',
   },
   { id: 'ocr', label: 'OCR解析設定', icon: ScanText, description: '設定 OCR 解析模型與參數' },
 ];
@@ -169,6 +215,19 @@ const TABS: { id: SettingsTab; label: string; icon: React.ElementType; descripti
 const ENV_IMPORT_TOOLTIP = `從 .env 或 JSON 導入\n支援兩種格式：\n• .env：KEY=value 或 export KEY=value\n• JSON：{"OPENAI_API_KEY":"sk-..."} 等頂層 key\n變數名大小寫不拘、拼寫需正確；僅下列金鑰會被辨識：${SUPPORTED_AI_ENV_KEY_NAMES.join('、')}`;
 
 const OCR_HIDDEN_MODULE_KEYS = [
+  'web_assistant',
+  'contract_assistant',
+  'blog_generator',
+  'property_description',
+  'ad_generator',
+  'software_dev_engineer',
+  'ttd_engineer',
+];
+
+/** 與 `evaluations-global-test` 獨立頁相同的隱藏模組（全域評測不顯示 OCR／部落格等欄） */
+const EVALUATIONS_GLOBAL_HIDDEN_MODULE_KEYS = [
+  'online_ocr_parse',
+  'online_ocr_judge',
   'web_assistant',
   'contract_assistant',
   'blog_generator',
@@ -195,12 +254,36 @@ const SHEET_TABS: SheetTabDef[] = [
     activeColor: 'bg-violet-600 text-white',
   },
   {
+    id: 'evaluations-global',
+    label: '',
+    zhLabel: 'AI 模型全域評測',
+    icon: FlaskConical,
+    color: 'text-emerald-600',
+    activeColor: 'bg-emerald-600 text-white',
+  },
+  {
     id: 'adapter-config',
-    label: 'Adapter Config',
-    zhLabel: 'Adapter調適與設定',
+    label: '',
+    zhLabel: 'LLM CLI Adapter調適',
     icon: Bot,
     color: 'text-teal-600',
     activeColor: 'bg-teal-600 text-white',
+  },
+  {
+    id: 'http-adapter-config',
+    label: '',
+    zhLabel: 'LLM Http Adapter調適',
+    icon: Bot,
+    color: 'text-indigo-600',
+    activeColor: 'bg-indigo-600 text-white',
+  },
+  {
+    id: 'model-router',
+    label: 'Model Router',
+    zhLabel: '模型路由策略',
+    icon: Route,
+    color: 'text-cyan-600',
+    activeColor: 'bg-cyan-600 text-white',
   },
   { id: 'ocr', label: 'OCR', zhLabel: 'OCR解析設定', icon: ScanText, color: 'text-blue-600', activeColor: 'bg-blue-600 text-white' },
 ];
@@ -215,27 +298,11 @@ const ADAPTER_PROVIDER_LABEL: Record<string, string> = {
 
 type AdapterRunStatus = 'idle' | 'running' | 'paused' | 'stopped';
 
-type AdapterConfigDraft = {
-  promptText: string;
-  selectedPromptId: string;
-  testFileName: string;
-  testFile: File | null;
-  /** 本輪測試開始時間（ms），供 UI 顯示經過秒數 */
-  runStartedAtMs: number | null;
-  runStatus: AdapterRunStatus;
-  outputLines: string[];
-  runCount: number;
-  logCursor: number;
-  pid: number | null;
-  commandPreview: string;
-  renderedOutput: string;
-  requestedModel: string;
-  effectiveModel: string;
-  modelSource: string;
-};
+type AdapterConfigDraft = AdapterConfigDraftCell;
 type AdapterPromptOption = { id: string; label: string; content: string };
 
 const LS_ADAPTER_RUN_SNAPSHOT = 'ai-settings:adapter-run-snapshot';
+const LS_HTTP_ADAPTER_RUN_SNAPSHOT = 'ai-settings:http-adapter-run-snapshot';
 const ADAPTER_RESULTS_MODULE_KEY = 'adapter_config_test_results';
 
 /** EnhancedTable：欄寬加總 100%，對應「編號 + 公司名稱 + …」共 10 欄 */
@@ -243,6 +310,9 @@ const ADAPTER_CONFIG_TABLE_ID = 'ai-settings-adapter-config-v1';
 const ADAPTER_CONFIG_TABLE_INITIAL_WIDTHS = [4, 7, 10, 14, 8, 10, 8, 14, 13, 12];
 /** 固定表格寬（搭配 stretchToContainer={false}），常見視窗寬度下才會出現底部橫向捲軸 */
 const ADAPTER_CONFIG_TABLE_MIN_WIDTH_PX = 2400;
+const HTTP_ADAPTER_CONFIG_TABLE_ID = 'ai-settings-http-adapter-config-v1';
+const HTTP_ADAPTER_CONFIG_TABLE_INITIAL_WIDTHS = [4, 7, 10, 14, 8, 10, 8, 14, 13, 12, 6, 6, 6, 6, 5, 8, 7];
+const HTTP_ADAPTER_CONFIG_TABLE_MIN_WIDTH_PX = 3200;
 
 const MAX_ADAPTER_RUN_NOTICES = 40;
 
@@ -261,6 +331,36 @@ type AdapterRunSnapshot = Record<
     'outputLines' | 'renderedOutput' | 'requestedModel' | 'effectiveModel' | 'modelSource' | 'commandPreview' | 'runCount'
   >
 >;
+
+function createDefaultAdapterDraft(
+  model: string,
+  snapshot?: Partial<AdapterRunSnapshot[string]>
+): AdapterConfigDraft {
+  return {
+    promptText: DEFAULT_ADAPTER_TEST_PROMPT,
+    selectedPromptId: '',
+    testFileName: '',
+    testFile: null,
+    runStartedAtMs: null,
+    runStatus: 'idle',
+    logCursor: 0,
+    pid: null,
+    commandPreview: snapshot?.commandPreview ?? '',
+    renderedOutput: snapshot?.renderedOutput ?? '',
+    requestedModel: snapshot?.requestedModel ?? model,
+    effectiveModel: snapshot?.effectiveModel ?? '',
+    modelSource: snapshot?.modelSource ?? '',
+    outputLines: snapshot?.outputLines ?? [],
+    runCount: snapshot?.runCount ?? 0,
+    ttftMs: null,
+    e2eLatencyMs: null,
+    tokensPerSec: null,
+    httpStatus: null,
+    retryCount: 0,
+    errorType: '',
+    successRateRecent: null,
+  };
+}
 
 function formatAdapterNoticeTime(iso: string): string {
   try {
@@ -293,6 +393,34 @@ function BulkRunElapsed({ startMs }: { startMs: number }) {
       {((Date.now() - startMs) / 1000).toFixed(1)}s
     </span>
   );
+}
+
+function isAdapterRunActive(status: AdapterRunStatus | undefined): boolean {
+  return status === 'running' || status === 'paused';
+}
+
+/**
+ * 全測：等所有列都不再進行中（非 running / 非 paused）後才 resolve。
+ * startAdapterRun 只等「啟動」完成，故批次必須額外等待各輪詢直到 idle/stopped。
+ */
+function waitForAllAdapterRunsSettled(
+  getDrafts: () => Record<string, AdapterConfigDraft>,
+  pollMs = 400
+): Promise<void> {
+  return new Promise((resolve) => {
+    const step = () => {
+      const drafts = getDrafts();
+      const anyActive = ADAPTER_CONFIG_ITEMS.some((item) =>
+        isAdapterRunActive(drafts[item.id]?.runStatus)
+      );
+      if (!anyActive) {
+        resolve();
+        return;
+      }
+      setTimeout(step, pollMs);
+    };
+    step();
+  });
 }
 
 function buildAdapterCommand(
@@ -350,11 +478,23 @@ export default function AIServiceSettingsPage() {
     tooltip: string;
     batchProgress: { tested: number; total: number; succeeded: number; failed: number } | null;
     testableCount: number;
+    batchTestableCount?: number;
     selectedCount: number;
     totalCount: number;
     filteredTotal: number;
     filteredSelectedCount: number;
+    lastBatchTestSummary?: {
+      selectedBeforeTest: number;
+      total: number;
+      succeeded: number;
+      failed: number;
+    } | null;
+    hasRecentBatchReport?: boolean;
+    openRecentBatchReport?: () => void;
+    applyRecentBatchReport?: () => Promise<void>;
+    applyingRecentBatchReport?: boolean;
   } | null>(null);
+  const [showPromptManager, setShowPromptManager] = useState(false);
   useEffect(() => {
     keysRef.current = settings.keys;
   }, [settings.keys]);
@@ -378,6 +518,15 @@ export default function AIServiceSettingsPage() {
     writeLocalStorage(LS_GLOBAL_PROMPT, globalTestPrompt);
   }, [globalTestPrompt]);
   useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (typeof window === 'undefined' || event.origin !== window.location.origin) return;
+      if (event.data?.type !== PROMPT_LOAD_MESSAGE_TYPE || !event.data?.content) return;
+      setGlobalTestPrompt(event.data.content);
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, []);
+  useEffect(() => {
     writeLocalStorage<SavedPrompt[]>(LS_SAVED_PROMPTS, savedPrompts);
   }, [savedPrompts]);
   useEffect(() => {
@@ -390,6 +539,10 @@ export default function AIServiceSettingsPage() {
   const [importingSettings, setImportingSettings] = useState(false);
   const [bulkStarting, setBulkStarting] = useState(false);
   const [bulkRunStartedAtMs, setBulkRunStartedAtMs] = useState<number | null>(null);
+  const [httpBulkStarting, setHttpBulkStarting] = useState(false);
+  const [httpBulkRunStartedAtMs, setHttpBulkRunStartedAtMs] = useState<number | null>(null);
+  const [httpBulkToast, setHttpBulkToast] = useState<string | null>(null);
+  const httpBulkToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [adapterRunNotices, setAdapterRunNotices] = useState<AdapterRunNoticeEntry[]>([]);
   const [adapterConfigDrafts, setAdapterConfigDrafts] = useState<Record<string, AdapterConfigDraft>>(() =>
     {
@@ -397,33 +550,37 @@ export default function AIServiceSettingsPage() {
       return Object.fromEntries(
         ADAPTER_CONFIG_ITEMS.map((item) => [
           item.id,
-          {
-            promptText: DEFAULT_ADAPTER_TEST_PROMPT,
-            selectedPromptId: '',
-            testFileName: '',
-            testFile: null,
-            runStartedAtMs: null,
-            runStatus: 'idle' as AdapterRunStatus,
-            logCursor: 0,
-            pid: null,
-            commandPreview: persistedSnapshot[item.id]?.commandPreview ?? '',
-            renderedOutput: persistedSnapshot[item.id]?.renderedOutput ?? '',
-            requestedModel: persistedSnapshot[item.id]?.requestedModel ?? item.model,
-            effectiveModel: persistedSnapshot[item.id]?.effectiveModel ?? '',
-            modelSource: persistedSnapshot[item.id]?.modelSource ?? '',
-            outputLines: persistedSnapshot[item.id]?.outputLines ?? [],
-            runCount: persistedSnapshot[item.id]?.runCount ?? 0,
-          },
+          createDefaultAdapterDraft(item.model, persistedSnapshot[item.id]),
+        ])
+      );
+    }
+  );
+  const [httpAdapterConfigDrafts, setHttpAdapterConfigDrafts] = useState<Record<string, AdapterConfigDraft>>(() =>
+    {
+      const persistedSnapshot = readLocalStorage<AdapterRunSnapshot>(LS_HTTP_ADAPTER_RUN_SNAPSHOT, {});
+      return Object.fromEntries(
+        ADAPTER_CONFIG_ITEMS.map((item) => [
+          item.id,
+          createDefaultAdapterDraft(item.model, persistedSnapshot[item.id]),
         ])
       );
     }
   );
   const [adapterPromptOptions, setAdapterPromptOptions] = useState<AdapterPromptOption[]>([]);
   const adapterPollIntervalRefs = useRef<Record<string, ReturnType<typeof setInterval> | null>>({});
+  const httpAdapterPollIntervalRefs = useRef<Record<string, ReturnType<typeof setInterval> | null>>({});
   const adapterFileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+  const httpAdapterFileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
   const adapterDraftsRef = useRef(adapterConfigDrafts);
+  const httpAdapterDraftsRef = useRef(httpAdapterConfigDrafts);
   const prevAdapterRunStatusRef = useRef<Record<string, AdapterRunStatus>>({});
+  const prevHttpAdapterRunStatusRef = useRef<Record<string, AdapterRunStatus>>({});
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (httpBulkToastTimerRef.current) clearTimeout(httpBulkToastTimerRef.current);
+    };
+  }, []);
 
   const appendAdapterRunNotice = useCallback((entry: Omit<AdapterRunNoticeEntry, 'id' | 'at'>) => {
     setAdapterRunNotices((prev) => {
@@ -447,6 +604,9 @@ export default function AIServiceSettingsPage() {
   useEffect(() => {
     adapterDraftsRef.current = adapterConfigDrafts;
   }, [adapterConfigDrafts]);
+  useEffect(() => {
+    httpAdapterDraftsRef.current = httpAdapterConfigDrafts;
+  }, [httpAdapterConfigDrafts]);
   const promptOptions = adapterPromptOptions;
 
   useEffect(() => {
@@ -454,23 +614,16 @@ export default function AIServiceSettingsPage() {
       const next = { ...prev };
       for (const item of ADAPTER_CONFIG_ITEMS) {
         if (!next[item.id]) {
-          next[item.id] = {
-            promptText: DEFAULT_ADAPTER_TEST_PROMPT,
-            selectedPromptId: '',
-            testFileName: '',
-            testFile: null,
-            runStartedAtMs: null,
-            runStatus: 'idle',
-            outputLines: [],
-            runCount: 0,
-            logCursor: 0,
-            pid: null,
-            commandPreview: '',
-            renderedOutput: '',
-            requestedModel: item.model,
-            effectiveModel: '',
-            modelSource: '',
-          };
+          next[item.id] = createDefaultAdapterDraft(item.model);
+        }
+      }
+      return next;
+    });
+    setHttpAdapterConfigDrafts((prev) => {
+      const next = { ...prev };
+      for (const item of ADAPTER_CONFIG_ITEMS) {
+        if (!next[item.id]) {
+          next[item.id] = createDefaultAdapterDraft(item.model);
         }
       }
       return next;
@@ -494,15 +647,59 @@ export default function AIServiceSettingsPage() {
     ) as AdapterRunSnapshot;
     writeLocalStorage(LS_ADAPTER_RUN_SNAPSHOT, snapshot);
   }, [adapterConfigDrafts]);
+  useEffect(() => {
+    const snapshot = Object.fromEntries(
+      Object.entries(httpAdapterConfigDrafts).map(([adapterId, draft]) => [
+        adapterId,
+        {
+          outputLines: draft.outputLines,
+          renderedOutput: draft.renderedOutput,
+          requestedModel: draft.requestedModel,
+          effectiveModel: draft.effectiveModel,
+          modelSource: draft.modelSource,
+          commandPreview: draft.commandPreview,
+          runCount: draft.runCount,
+        },
+      ])
+    ) as AdapterRunSnapshot;
+    writeLocalStorage(LS_HTTP_ADAPTER_RUN_SNAPSHOT, snapshot);
+  }, [httpAdapterConfigDrafts]);
 
   useEffect(() => {
     const cloudModule = settings.modules.find((m) => m.module_key === ADAPTER_RESULTS_MODULE_KEY);
     const cloudSnapshot = (cloudModule?.config?.adapterSnapshots ?? null) as AdapterRunSnapshot | null;
-    if (!cloudSnapshot || typeof cloudSnapshot !== 'object') return;
-    setAdapterConfigDrafts((prev) => {
+    const cloudHttpSnapshot = (cloudModule?.config?.httpAdapterSnapshots ?? null) as AdapterRunSnapshot | null;
+    if (cloudSnapshot && typeof cloudSnapshot === 'object') {
+      setAdapterConfigDrafts((prev) => {
+        const next = { ...prev };
+        for (const item of ADAPTER_CONFIG_ITEMS) {
+          const snap = cloudSnapshot[item.id];
+          if (!snap) continue;
+          const current = next[item.id];
+          if (!current) continue;
+          next[item.id] = {
+            ...current,
+            outputLines: Array.isArray(snap.outputLines) ? snap.outputLines.slice(-120) : current.outputLines,
+            renderedOutput: typeof snap.renderedOutput === 'string' ? snap.renderedOutput : current.renderedOutput,
+            requestedModel: typeof snap.requestedModel === 'string' ? snap.requestedModel : current.requestedModel,
+            effectiveModel: typeof snap.effectiveModel === 'string' ? snap.effectiveModel : current.effectiveModel,
+            modelSource: typeof snap.modelSource === 'string' ? snap.modelSource : current.modelSource,
+            commandPreview: typeof snap.commandPreview === 'string' ? snap.commandPreview : current.commandPreview,
+            runCount: typeof snap.runCount === 'number' ? snap.runCount : current.runCount,
+            runStartedAtMs: null,
+            runStatus: 'stopped',
+            pid: null,
+            logCursor: 0,
+          };
+        }
+        return next;
+      });
+    }
+    if (!cloudHttpSnapshot || typeof cloudHttpSnapshot !== 'object') return;
+    setHttpAdapterConfigDrafts((prev) => {
       const next = { ...prev };
       for (const item of ADAPTER_CONFIG_ITEMS) {
-        const snap = cloudSnapshot[item.id];
+        const snap = cloudHttpSnapshot[item.id];
         if (!snap) continue;
         const current = next[item.id];
         if (!current) continue;
@@ -543,6 +740,20 @@ export default function AIServiceSettingsPage() {
           },
         ])
       ) as AdapterRunSnapshot;
+      const httpSnapshot = Object.fromEntries(
+        Object.entries(httpAdapterDraftsRef.current).map(([adapterId, draft]) => [
+          adapterId,
+          {
+            outputLines: draft.outputLines.slice(-120),
+            renderedOutput: draft.renderedOutput,
+            requestedModel: draft.requestedModel,
+            effectiveModel: draft.effectiveModel,
+            modelSource: draft.modelSource,
+            commandPreview: draft.commandPreview,
+            runCount: draft.runCount,
+          },
+        ])
+      ) as AdapterRunSnapshot;
       try {
         await settings.saveModule(
           ADAPTER_RESULTS_MODULE_KEY,
@@ -551,6 +762,7 @@ export default function AIServiceSettingsPage() {
           undefined,
           {
             adapterSnapshots: snapshot,
+            httpAdapterSnapshots: httpSnapshot,
             updatedAt: new Date().toISOString(),
           }
         );
@@ -561,7 +773,7 @@ export default function AIServiceSettingsPage() {
     return () => {
       if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
     };
-  }, [adapterConfigDrafts, settings.userId, settings.saveModule]);
+  }, [adapterConfigDrafts, httpAdapterConfigDrafts, settings.userId, settings.saveModule]);
 
   useEffect(() => {
     let mounted = true;
@@ -594,40 +806,59 @@ export default function AIServiceSettingsPage() {
           clearInterval(timer);
         }
       }
+      for (const key of Object.keys(httpAdapterPollIntervalRefs.current)) {
+        const timer = httpAdapterPollIntervalRefs.current[key];
+        if (timer) {
+          clearInterval(timer);
+        }
+      }
     };
   }, []);
 
-  const stopAdapterPolling = useCallback((adapterId: string) => {
-    const timer = adapterPollIntervalRefs.current[adapterId];
+  type AdapterRunApiResponse = {
+    success: boolean;
+    message?: string;
+    status: AdapterRunStatus;
+    logs: string[];
+    cursor: number;
+    command: string;
+    pid: number | null;
+    resultText: string;
+    requestedModel: string;
+    effectiveModel: string;
+    modelSource: string;
+    ttftMs?: number | null;
+    e2eLatencyMs?: number | null;
+    tokensPerSec?: number | null;
+    httpStatus?: number | null;
+    retryCount?: number;
+    errorType?: string;
+    successRateRecent?: number | null;
+  };
+
+  const stopAdapterPolling = useCallback((adapterId: string, mode: 'cli' | 'http' = 'cli') => {
+    const ref = mode === 'http' ? httpAdapterPollIntervalRefs.current : adapterPollIntervalRefs.current;
+    const timer = ref[adapterId];
     if (timer) {
       clearInterval(timer);
-      adapterPollIntervalRefs.current[adapterId] = null;
+      ref[adapterId] = null;
     }
   }, []);
 
-  const pollAdapterRun = useCallback(async (adapterId: string) => {
-    const draft = adapterDraftsRef.current[adapterId];
+  const pollAdapterRun = useCallback(async (adapterId: string, mode: 'cli' | 'http' = 'cli') => {
+    const draftsRef = mode === 'http' ? httpAdapterDraftsRef : adapterDraftsRef;
+    const setDrafts = mode === 'http' ? setHttpAdapterConfigDrafts : setAdapterConfigDrafts;
+    const draft = draftsRef.current[adapterId];
     if (!draft) return;
-    const res = await fetch(`/api/ai-settings/adapter-runs?adapterId=${encodeURIComponent(adapterId)}&cursor=${draft.logCursor}`);
-    const data = await res.json() as {
-      success: boolean;
-      status: AdapterRunStatus;
-      logs: string[];
-      cursor: number;
-      command: string;
-      pid: number | null;
-      resultText: string;
-      requestedModel: string;
-      effectiveModel: string;
-      modelSource: string;
-    };
+    const res = await fetch(`/api/ai-settings/adapter-runs?adapterId=${encodeURIComponent(adapterId)}&cursor=${draft.logCursor}&mode=${mode}`);
+    const data = await res.json() as AdapterRunApiResponse;
     if (!data.success) return;
-    setAdapterConfigDrafts((prev) => {
+    setDrafts((prev) => {
       const current = prev[adapterId];
       if (!current) return prev;
       const nextStatus = data.status;
       if (nextStatus === 'idle' || nextStatus === 'stopped') {
-        stopAdapterPolling(adapterId);
+        stopAdapterPolling(adapterId, mode);
       }
       let runStartedAtMs = current.runStartedAtMs;
       if (nextStatus === 'running') {
@@ -649,43 +880,48 @@ export default function AIServiceSettingsPage() {
           requestedModel: data.requestedModel || current.requestedModel,
           effectiveModel: data.effectiveModel || current.effectiveModel,
           modelSource: data.modelSource || current.modelSource,
+          ttftMs: data.ttftMs ?? current.ttftMs,
+          e2eLatencyMs: data.e2eLatencyMs ?? current.e2eLatencyMs,
+          tokensPerSec: data.tokensPerSec ?? current.tokensPerSec,
+          httpStatus: data.httpStatus ?? current.httpStatus,
+          retryCount: data.retryCount ?? current.retryCount,
+          errorType: data.errorType ?? current.errorType,
+          successRateRecent: data.successRateRecent ?? current.successRateRecent,
         },
       };
     });
   }, [stopAdapterPolling]);
 
-  const startAdapterPolling = useCallback((adapterId: string) => {
-    stopAdapterPolling(adapterId);
+  const startAdapterPolling = useCallback((adapterId: string, mode: 'cli' | 'http' = 'cli') => {
+    stopAdapterPolling(adapterId, mode);
     const timer = setInterval(() => {
-      void pollAdapterRun(adapterId);
+      void pollAdapterRun(adapterId, mode);
     }, 1500);
+    if (mode === 'http') {
+      httpAdapterPollIntervalRefs.current[adapterId] = timer;
+      return;
+    }
     adapterPollIntervalRefs.current[adapterId] = timer;
   }, [pollAdapterRun, stopAdapterPolling]);
 
-  const startAdapterRun = useCallback(async (item: (typeof ADAPTER_CONFIG_ITEMS)[number], draft: AdapterConfigDraft) => {
+  const startAdapterRun = useCallback(async (
+    item: (typeof ADAPTER_CONFIG_ITEMS)[number],
+    draft: AdapterConfigDraft,
+    mode: 'cli' | 'http' = 'cli'
+  ) => {
+    const setDrafts = mode === 'http' ? setHttpAdapterConfigDrafts : setAdapterConfigDrafts;
     const form = new FormData();
     form.append('adapterId', item.id);
     form.append('provider', item.provider);
     form.append('model', item.model);
+    form.append('mode', mode);
     form.append('prompt', draft.promptText.trim() || DEFAULT_ADAPTER_TEST_PROMPT);
     if (draft.testFile) form.append('file', draft.testFile);
     const res = await fetch('/api/ai-settings/adapter-runs', {
       method: 'POST',
       body: form,
     });
-    let data: {
-      success: boolean;
-      message?: string;
-      status: AdapterRunStatus;
-      logs: string[];
-      cursor: number;
-      command: string;
-      pid: number | null;
-      resultText: string;
-      requestedModel: string;
-      effectiveModel: string;
-      modelSource: string;
-    };
+    let data: AdapterRunApiResponse;
     try {
       data = await res.json() as typeof data;
     } catch {
@@ -707,7 +943,7 @@ export default function AIServiceSettingsPage() {
       return;
     }
     const running = data.status === 'running';
-    setAdapterConfigDrafts((prev) => ({
+    setDrafts((prev) => ({
       ...prev,
       [item.id]: {
         ...prev[item.id],
@@ -722,30 +958,30 @@ export default function AIServiceSettingsPage() {
         requestedModel: data.requestedModel ?? item.model,
         effectiveModel: data.effectiveModel ?? '',
         modelSource: data.modelSource ?? '',
+        ttftMs: data.ttftMs ?? null,
+        e2eLatencyMs: data.e2eLatencyMs ?? null,
+        tokensPerSec: data.tokensPerSec ?? null,
+        httpStatus: data.httpStatus ?? null,
+        retryCount: data.retryCount ?? 0,
+        errorType: data.errorType ?? '',
+        successRateRecent: data.successRateRecent ?? null,
       },
     }));
-    startAdapterPolling(item.id);
+    startAdapterPolling(item.id, mode);
   }, [appendAdapterRunNotice, startAdapterPolling]);
 
-  const controlAdapterRun = useCallback(async (adapterId: string, action: 'pause' | 'resume' | 'stop') => {
+  const controlAdapterRun = useCallback(async (
+    adapterId: string,
+    action: 'pause' | 'resume' | 'stop',
+    mode: 'cli' | 'http' = 'cli'
+  ) => {
+    const setDrafts = mode === 'http' ? setHttpAdapterConfigDrafts : setAdapterConfigDrafts;
     const res = await fetch('/api/ai-settings/adapter-runs', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ adapterId, action }),
+      body: JSON.stringify({ adapterId, action, mode }),
     });
-    let data: {
-      success: boolean;
-      message?: string;
-      status: AdapterRunStatus;
-      logs: string[];
-      cursor: number;
-      command: string;
-      pid: number | null;
-      resultText: string;
-      requestedModel: string;
-      effectiveModel: string;
-      modelSource: string;
-    };
+    let data: AdapterRunApiResponse;
     try {
       data = await res.json() as typeof data;
     } catch {
@@ -768,7 +1004,7 @@ export default function AIServiceSettingsPage() {
       });
       return;
     }
-    setAdapterConfigDrafts((prev) => {
+    setDrafts((prev) => {
       const current = prev[adapterId];
       if (!current) return prev;
       const nextStatus = data.status;
@@ -792,13 +1028,20 @@ export default function AIServiceSettingsPage() {
           requestedModel: data.requestedModel || current.requestedModel,
           effectiveModel: data.effectiveModel || current.effectiveModel,
           modelSource: data.modelSource || current.modelSource,
+          ttftMs: data.ttftMs ?? current.ttftMs,
+          e2eLatencyMs: data.e2eLatencyMs ?? current.e2eLatencyMs,
+          tokensPerSec: data.tokensPerSec ?? current.tokensPerSec,
+          httpStatus: data.httpStatus ?? current.httpStatus,
+          retryCount: data.retryCount ?? current.retryCount,
+          errorType: data.errorType ?? current.errorType,
+          successRateRecent: data.successRateRecent ?? current.successRateRecent,
         },
       };
     });
     if (action === 'stop') {
-      stopAdapterPolling(adapterId);
+      stopAdapterPolling(adapterId, mode);
     } else {
-      startAdapterPolling(adapterId);
+      startAdapterPolling(adapterId, mode);
     }
   }, [appendAdapterRunNotice, startAdapterPolling, stopAdapterPolling]);
 
@@ -820,6 +1063,8 @@ export default function AIServiceSettingsPage() {
           effectiveModel: effective,
           renderedOutput: draft.renderedOutput,
           outputLines: draft.outputLines,
+          errorType: draft.errorType,
+          httpStatus: draft.httpStatus,
         });
         if (evaluation.level === 'fail' || evaluation.level === 'warning') {
           appendAdapterRunNotice({
@@ -833,6 +1078,39 @@ export default function AIServiceSettingsPage() {
     }
   }, [adapterConfigDrafts, appendAdapterRunNotice]);
 
+  useEffect(() => {
+    for (const item of ADAPTER_CONFIG_ITEMS) {
+      const draft = httpAdapterConfigDrafts[item.id];
+      if (!draft) continue;
+      const cur = draft.runStatus;
+      const prev = prevHttpAdapterRunStatusRef.current[item.id];
+      if (
+        prev !== undefined &&
+        prev === 'running' &&
+        (cur === 'stopped' || cur === 'idle')
+      ) {
+        const requested = (draft.requestedModel?.trim() || item.model).trim();
+        const effective = (draft.effectiveModel?.trim() || '').trim();
+        const evaluation = evaluateAdapterRun({
+          requestedModel: requested,
+          effectiveModel: effective,
+          renderedOutput: draft.renderedOutput,
+          outputLines: draft.outputLines,
+          errorType: draft.errorType,
+          httpStatus: draft.httpStatus,
+        });
+        if (evaluation.level === 'fail' || evaluation.level === 'warning') {
+          appendAdapterRunNotice({
+            severity: evaluation.level === 'fail' ? 'error' : 'warn',
+            adapterLabel: `${item.optionLabel}（HTTP）`,
+            message: evaluation.message,
+          });
+        }
+      }
+      prevHttpAdapterRunStatusRef.current[item.id] = cur;
+    }
+  }, [httpAdapterConfigDrafts, appendAdapterRunNotice]);
+
   const runAllAdapters = useCallback(async () => {
     if (bulkStarting) return;
     setBulkStarting(true);
@@ -843,14 +1121,59 @@ export default function AIServiceSettingsPage() {
         const draft = drafts[item.id];
         if (!draft) return;
         if (draft.runStatus === 'running') return;
-        await startAdapterRun(item, draft);
+        await startAdapterRun(item, draft, 'cli');
       });
       await Promise.allSettled(tasks);
+      await new Promise((r) => setTimeout(r, 0));
+      await waitForAllAdapterRunsSettled(() => adapterDraftsRef.current);
     } finally {
       setBulkStarting(false);
       setBulkRunStartedAtMs(null);
     }
   }, [bulkStarting, startAdapterRun]);
+  const runAllHttpAdapters = useCallback(async () => {
+    if (httpBulkStarting) return;
+    setHttpBulkStarting(true);
+    setHttpBulkRunStartedAtMs(Date.now());
+    const beforeRunCountById = Object.fromEntries(
+      ADAPTER_CONFIG_ITEMS.map((item) => [item.id, httpAdapterDraftsRef.current[item.id]?.runCount ?? 0])
+    ) as Record<string, number>;
+    const draftsAtBatchStart = httpAdapterDraftsRef.current;
+    try {
+      const drafts = draftsAtBatchStart;
+      const tasks = ADAPTER_CONFIG_ITEMS.map(async (item) => {
+        const draft = drafts[item.id];
+        if (!draft) return;
+        if (draft.runStatus === 'running') return;
+        await startAdapterRun(item, draft, 'http');
+      });
+      await Promise.allSettled(tasks);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await waitForAllAdapterRunsSettled(() => httpAdapterDraftsRef.current);
+      const attempted = ADAPTER_CONFIG_ITEMS.filter((item) => {
+        const d = draftsAtBatchStart[item.id];
+        if (!d) return false;
+        if (d.runStatus === 'running') return false;
+        return true;
+      }).length;
+      const started = ADAPTER_CONFIG_ITEMS.filter((item) => {
+        const before = beforeRunCountById[item.id] ?? 0;
+        const after = httpAdapterDraftsRef.current[item.id]?.runCount ?? before;
+        return after > before;
+      }).length;
+      const failed = Math.max(0, attempted - started);
+      const message = `HTTP 全測完成｜嘗試 ${attempted} 家、成功 ${started} 家、失敗 ${failed} 家`;
+      setHttpBulkToast(message);
+      if (httpBulkToastTimerRef.current) clearTimeout(httpBulkToastTimerRef.current);
+      httpBulkToastTimerRef.current = setTimeout(() => {
+        setHttpBulkToast(null);
+        httpBulkToastTimerRef.current = null;
+      }, 3500);
+    } finally {
+      setHttpBulkStarting(false);
+      setHttpBulkRunStartedAtMs(null);
+    }
+  }, [httpBulkStarting, startAdapterRun]);
 
   const handleExportSettings = useCallback(async () => {
     setExportingSettings(true);
@@ -926,6 +1249,7 @@ export default function AIServiceSettingsPage() {
         return 'ocr';
       case 'keys':
       case 'llm-leaderboard':
+      case 'evaluations-global':
       default:
         return 'general';
     }
@@ -1027,6 +1351,7 @@ export default function AIServiceSettingsPage() {
         return 'eval_ocr_global_prompt';
       case 'keys':
       case 'llm-leaderboard':
+      case 'evaluations-global':
       default:
         return 'eval_general_global_prompt';
     }
@@ -1161,23 +1486,7 @@ export default function AIServiceSettingsPage() {
       for (const item of items) {
         serial += 1;
         const draft =
-          adapterConfigDrafts[item.id] ?? {
-            promptText: DEFAULT_ADAPTER_TEST_PROMPT,
-            selectedPromptId: '',
-            testFileName: '',
-            testFile: null,
-            runStartedAtMs: null,
-            runStatus: 'idle' as AdapterRunStatus,
-            outputLines: [],
-            runCount: 0,
-            logCursor: 0,
-            pid: null,
-            commandPreview: '',
-            renderedOutput: '',
-            requestedModel: item.model,
-            effectiveModel: '',
-            modelSource: '',
-          };
+          adapterConfigDrafts[item.id] ?? createDefaultAdapterDraft(item.model);
         rows.push({
           serialNo: serial,
           provider,
@@ -1189,6 +1498,24 @@ export default function AIServiceSettingsPage() {
     }
     return rows;
   }, [adapterConfigGroups, adapterConfigDrafts]);
+  const httpAdapterTableRows = useMemo((): AdapterConfigTableRow[] => {
+    let serial = 0;
+    const rows: AdapterConfigTableRow[] = [];
+    for (const [provider, items] of adapterConfigGroups) {
+      for (const item of items) {
+        serial += 1;
+        const draft = httpAdapterConfigDrafts[item.id] ?? createDefaultAdapterDraft(item.model);
+        rows.push({
+          serialNo: serial,
+          provider,
+          item,
+          draft,
+          commandPreview: `HTTP ${item.provider} ${item.model}`,
+        });
+      }
+    }
+    return rows;
+  }, [adapterConfigGroups, httpAdapterConfigDrafts]);
 
   const adapterConfigTableColumns = useMemo(
     () =>
@@ -1202,6 +1529,20 @@ export default function AIServiceSettingsPage() {
       }),
     [promptOptions, startAdapterRun, controlAdapterRun],
   );
+  const httpAdapterConfigTableColumns = useMemo(
+    () =>
+      createAdapterConfigColumns({
+        providerLabel: ADAPTER_PROVIDER_LABEL,
+        promptOptions,
+        adapterFileInputRefs: httpAdapterFileInputRefs,
+        setAdapterConfigDrafts: setHttpAdapterConfigDrafts,
+        startAdapterRun: (item, draft) => startAdapterRun(item, draft, 'http'),
+        controlAdapterRun: (adapterId, action) => controlAdapterRun(adapterId, action, 'http'),
+        showHttpMetrics: true,
+      }),
+    [promptOptions, startAdapterRun, controlAdapterRun],
+  );
+  const modelRouterColumns = useMemo(() => createModelRouterColumns(), []);
 
   const getAdapterConfigSearchValue = useCallback((row: AdapterConfigTableRow) => {
     const { item, draft, provider, serialNo } = row;
@@ -1224,6 +1565,92 @@ export default function AIServiceSettingsPage() {
   const getAdapterConfigCategoryValue = useCallback(
     (row: AdapterConfigTableRow) => ADAPTER_PROVIDER_LABEL[row.provider] ?? row.provider,
     [],
+  );
+  const getModelRouterSearchValue = useCallback((row: ModelRouterRow) => {
+    return [
+      row.id,
+      row.scenario,
+      row.owner,
+      row.primaryModel,
+      row.fallbackChain,
+      row.triggerRule,
+      row.status,
+      row.notes,
+    ].join(' ');
+  }, []);
+  const getModelRouterCategoryValue = useCallback((row: ModelRouterRow) => row.status, []);
+  const adapterCompareSummary = useMemo(() => {
+    const collect = (drafts: Record<string, AdapterConfigDraft>) => {
+      const all = Object.values(drafts);
+      const measured = all.filter((d) => d.e2eLatencyMs != null);
+      const latency = measured
+        .map((d) => d.e2eLatencyMs as number)
+        .sort((a, b) => a - b);
+      const ttft = measured
+        .map((d) => d.ttftMs)
+        .filter((v): v is number => typeof v === 'number')
+        .sort((a, b) => a - b);
+      const p = (arr: number[], ratio: number) =>
+        arr.length ? arr[Math.min(arr.length - 1, Math.floor((arr.length - 1) * ratio))] : null;
+      const successCount = all.filter((d) => !!d.renderedOutput && !d.errorType).length;
+      const timeoutCount = all.filter((d) => d.errorType === 'timeout').length;
+      const serverErrCount = all.filter((d) => (d.httpStatus ?? 0) >= 500).length;
+      const avgRetry = all.length
+        ? all.reduce((sum, d) => sum + (d.retryCount ?? 0), 0) / all.length
+        : 0;
+      return {
+        total: all.length,
+        p50Latency: p(latency, 0.5),
+        p95Latency: p(latency, 0.95),
+        p50Ttft: p(ttft, 0.5),
+        successRate: all.length ? successCount / all.length : 0,
+        timeoutRate: all.length ? timeoutCount / all.length : 0,
+        serverErrRate: all.length ? serverErrCount / all.length : 0,
+        avgRetry,
+      };
+    };
+    return {
+      cli: collect(adapterConfigDrafts),
+      http: collect(httpAdapterConfigDrafts),
+    };
+  }, [adapterConfigDrafts, httpAdapterConfigDrafts]);
+
+  const renderAdapterRunNoticesColumn = () => (
+    <div className="min-w-0 flex-1 border-t border-border-default pt-4 lg:max-w-md lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0">
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-xs font-semibold text-text-primary">最近測試錯誤／警告</p>
+        <button
+          type="button"
+          onClick={() => setAdapterRunNotices([])}
+          disabled={adapterRunNotices.length === 0}
+          className="shrink-0 rounded px-2 py-0.5 text-[11px] font-medium text-text-muted transition hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          清除
+        </button>
+      </div>
+      {adapterRunNotices.length === 0 ? (
+        <p className="mt-2 text-[11px] leading-relaxed text-text-muted">
+          尚無紀錄。啟動失敗、遠端操作失敗，或單次執行結束後評價為「不及格／模型不正確」時會列在此，方便對照（關閉彈窗後仍可回看）。
+        </p>
+      ) : (
+        <ul className="mt-2 max-h-36 space-y-2 overflow-y-auto pr-0.5">
+          {adapterRunNotices.map((n) => (
+            <li
+              key={n.id}
+              className={`rounded-md border px-2.5 py-1.5 text-[11px] leading-snug ${
+                n.severity === 'error'
+                  ? 'border-rose-200 bg-rose-50/80 text-rose-900'
+                  : 'border-amber-200 bg-amber-50/80 text-amber-950'
+              }`}
+            >
+              <span className="font-medium text-text-secondary">{formatAdapterNoticeTime(n.at)}</span>
+              <span className="text-text-muted"> · {n.adapterLabel}</span>
+              <p className="mt-0.5 break-words">{n.message}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 
   const renderContent = () => {
@@ -1253,7 +1680,6 @@ export default function AIServiceSettingsPage() {
         <ApiKeyManager
           ref={apiKeyManagerRef}
           savedKeys={settings.keys}
-          savedModels={settings.models}
           validateAllResultsByKeyId={validateAllResultsByKeyId}
           onSave={settings.saveKey}
           onDelete={settings.deleteKey}
@@ -1277,6 +1703,286 @@ export default function AIServiceSettingsPage() {
       return <LlmLeaderboardPanel />;
     }
 
+    if (activeTab === 'evaluations-global') {
+      const handleSaveModels = async (
+        providerId: string,
+        selections: { modelId: string; modelName: string; isPrimary: boolean }[],
+      ) => {
+        await settings.saveModels(
+          providerId as Parameters<typeof settings.saveModels>[0],
+          selections,
+        );
+      };
+      const handleSaveModule = async (
+        moduleKey: string,
+        isEnabled: boolean,
+        assignedModels: import('@/lib/hooks/useAISettings').AssignedModel[],
+        config?: Record<string, unknown>,
+      ) => {
+        await settings.saveModule(moduleKey, isEnabled, assignedModels, undefined, config);
+      };
+
+      return (
+        <div className="min-h-0 min-w-0 flex flex-col gap-3">
+          <p className="text-xs text-text-muted">
+            與專案進度 Development 表相同的邊框與標題列樣式；流程集中於下方單一工作表。
+          </p>
+          <div className="min-h-0 min-w-0 flex-1 overflow-auto rounded-base border border-border-default bg-bg-primary shadow-sm">
+            <table className="w-full border-collapse text-xs text-text-primary">
+              <thead>
+                <tr className="sticky top-0 z-[1] bg-bg-tertiary">
+                  <th
+                    scope="col"
+                    className="border border-border-default px-3 py-2.5 text-left text-[10px] font-semibold uppercase tracking-wide text-text-muted w-[200px]"
+                  >
+                    步驟
+                  </th>
+                  <th
+                    scope="col"
+                    className="border border-border-default px-3 py-2.5 text-left text-[10px] font-semibold uppercase tracking-wide text-text-muted"
+                  >
+                    說明與操作
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                    className="border border-border-default bg-bg-secondary/60 px-3 py-3 align-top text-left font-semibold text-text-secondary whitespace-nowrap"
+                  >
+                    ① 模型清單
+                  </th>
+                  <td className="border border-border-default p-0 align-top">
+                    <div className="min-h-[320px] max-h-[min(62vh,720px)] overflow-auto p-3 sm:p-4">
+                      <ModelEvaluator
+                        savedKeys={settings.keys}
+                        savedModels={settings.models}
+                        savedEvaluations={settings.evaluations}
+                        validateAllResultsByKeyId={validateAllResultsByKeyId}
+                        currentKeys={memoizedCurrentKeys}
+                        onSave={settings.saveEvaluations}
+                        onTestModel={settings.testModel}
+                        onSaveModels={handleSaveModels}
+                        savedModules={settings.modules}
+                        hiddenModuleKeys={EVALUATIONS_GLOBAL_HIDDEN_MODULE_KEYS}
+                        onSaveModule={handleSaveModule}
+                        summarySelectedCount={selectedModelCount}
+                        summaryTotalCount={totalAvailableModels}
+                        promptVariableLabel={
+                          currentCloudPromptName ? `{${currentCloudPromptName}}` : undefined
+                        }
+                        globalTestPrompt={globalTestPrompt}
+                        onChangeGlobalTestPrompt={setGlobalTestPrompt}
+                        uploadedFile={uploadedFile}
+                        onChangeUploadedFile={setUploadedFile}
+                        headerActionsRef={setModelEvaluatorHeaderActions}
+                      />
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                    className="border border-border-default bg-bg-secondary/60 px-3 py-3 align-top text-left font-semibold text-text-secondary"
+                  >
+                    ② 測試檔
+                  </th>
+                  <td className="border border-border-default px-3 py-3 sm:px-4 align-top">
+                    <div className="flex flex-wrap items-start gap-3">
+                      <label className="inline-flex items-center gap-1.5 cursor-pointer text-sm text-text-secondary hover:text-text-primary rounded border border-border-subtle bg-bg-primary px-3 py-2 shrink-0">
+                        <FlaskConical size={16} className="shrink-0" />
+                        <span>上傳測試檔案</span>
+                        <input
+                          type="file"
+                          accept=".pdf,.jpg,.jpeg,.png,.gif,.webp,.txt,.md"
+                          className="sr-only"
+                          onChange={(e) => {
+                            const f = e.target.files?.[0] ?? null;
+                            setUploadedFile(f);
+                            if (e.target) (e.target as HTMLInputElement).value = '';
+                          }}
+                          title="上傳 PDF、圖片或文字檔"
+                        />
+                      </label>
+                      {uploadedFile && (
+                        <span
+                          className="text-sm text-text-muted truncate max-w-[280px] py-2"
+                          title={uploadedFile.name}
+                        >
+                          {uploadedFile.name}
+                        </span>
+                      )}
+                      <div className="flex items-center gap-1.5 text-xs text-text-secondary py-2 shrink-0">
+                        <FlaskConical size={13} className="text-text-muted shrink-0" />
+                        <span>
+                          已選／可選{' '}
+                          <span className="font-semibold text-text-primary tabular-nums">
+                            {modelEvaluatorHeaderActions?.selectedCount ?? selectedModelCount}/
+                            {modelEvaluatorHeaderActions?.totalCount ?? totalAvailableModels}
+                          </span>
+                        </span>
+                        {modelEvaluatorHeaderActions != null && (
+                          <span
+                            className={`font-medium tabular-nums ${
+                              modelEvaluatorHeaderActions.testableCount > 0
+                                ? 'text-accent'
+                                : 'text-amber-500'
+                            }`}
+                          >
+                            · 可測試 {modelEvaluatorHeaderActions.testableCount}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                    className="border border-border-default bg-bg-secondary/60 px-3 py-3 align-top text-left font-semibold text-text-secondary"
+                  >
+                    ③ 全域 Prompt
+                  </th>
+                  <td className="border border-border-default px-3 py-3 sm:px-4 align-top">
+                    <textarea
+                      value={globalTestPrompt}
+                      onChange={(e) => setGlobalTestPrompt(e.target.value)}
+                      placeholder="全域評測 Prompt；每列可留空或填 {預設prompt} 使用此內容"
+                      rows={10}
+                      className="w-full rounded border border-border-subtle bg-bg-primary px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent resize-y min-h-[200px]"
+                    />
+                    <div className="mt-2 flex justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setShowPromptManager(true)}
+                        className="inline-flex items-center gap-1.5 text-sm text-text-secondary hover:text-text-primary rounded border border-border-subtle bg-bg-primary px-3 py-2 shrink-0 transition-colors"
+                        title="開啟 Prompt 管理，可載入至此欄位"
+                      >
+                        <BookMarked size={14} className="shrink-0" />
+                        <span>Prompt 管理</span>
+                      </button>
+                      <a
+                        href="/superadmin/settings/prompt-management?source=evaluations"
+                        target="_blank"
+                        rel="opener"
+                        className="inline-flex items-center gap-1.5 text-sm text-text-secondary hover:text-text-primary rounded border border-border-subtle bg-bg-primary px-3 py-2 shrink-0 transition-colors"
+                        title="在新分頁開啟 Prompt 管理，載入的 Prompt 會自動填到此欄位"
+                      >
+                        <ExternalLink size={14} className="shrink-0" />
+                        <span>在新分頁開啟</span>
+                      </a>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                    className="border border-border-default bg-bg-secondary/60 px-3 py-3 align-top text-left font-semibold text-text-secondary"
+                  >
+                    ④ 執行／報告
+                  </th>
+                  <td className="border border-border-default px-3 py-3 sm:px-4 align-top">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => modelEvaluatorHeaderActions?.runBatchTest()}
+                        isLoading={modelEvaluatorHeaderActions?.batchTesting}
+                        disabled={
+                          !modelEvaluatorHeaderActions?.canBatchTest ||
+                          !!modelEvaluatorHeaderActions?.batchTesting
+                        }
+                        title={
+                          modelEvaluatorHeaderActions?.tooltip ??
+                          '對目前已選且具金鑰的模型並行測試'
+                        }
+                        className="shrink-0"
+                      >
+                        {modelEvaluatorHeaderActions?.batchTesting ? (
+                          <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                          <FlaskConical size={14} />
+                        )}
+                        <span className="ml-1.5 whitespace-nowrap">開始全域評測</span>
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => modelEvaluatorHeaderActions?.abortBatchTest?.()}
+                        disabled={!modelEvaluatorHeaderActions?.batchTesting}
+                        title="中斷或暫停目前正在執行的評測（當前批次完成後停止）"
+                        className="shrink-0"
+                      >
+                        <Pause size={14} />
+                        <span className="ml-1.5 whitespace-nowrap">暫停測試</span>
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => modelEvaluatorHeaderActions?.openRecentBatchReport?.()}
+                        disabled={
+                          !modelEvaluatorHeaderActions?.hasRecentBatchReport ||
+                          !!modelEvaluatorHeaderActions?.batchTesting
+                        }
+                        title={
+                          modelEvaluatorHeaderActions?.hasRecentBatchReport
+                            ? '檢視最近一次批次測試報告'
+                            : '目前尚無可檢視的最近報告'
+                        }
+                        className="shrink-0"
+                      >
+                        <Eye size={14} />
+                        <span className="ml-1.5 whitespace-nowrap">檢視最近報告</span>
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => {
+                          void modelEvaluatorHeaderActions?.applyRecentBatchReport?.();
+                        }}
+                        isLoading={modelEvaluatorHeaderActions?.applyingRecentBatchReport}
+                        disabled={
+                          !modelEvaluatorHeaderActions?.hasRecentBatchReport ||
+                          !!modelEvaluatorHeaderActions?.batchTesting ||
+                          !!modelEvaluatorHeaderActions?.applyingRecentBatchReport
+                        }
+                        title={
+                          modelEvaluatorHeaderActions?.hasRecentBatchReport
+                            ? '依最近報告自動修正模型分類與狀態'
+                            : '目前尚無可套用的最近報告'
+                        }
+                        className="shrink-0"
+                      >
+                        <span className="ml-1.5 whitespace-nowrap">套用最近報告修正狀態</span>
+                      </Button>
+                      {modelEvaluatorHeaderActions?.batchProgress && (
+                        <span className="text-xs text-text-secondary tabular-nums">
+                          {modelEvaluatorHeaderActions.batchProgress.tested}/
+                          {modelEvaluatorHeaderActions.batchProgress.total}{' '}
+                          <span className="text-green-500">
+                            {modelEvaluatorHeaderActions.batchProgress.succeeded} 成功
+                          </span>
+                          {modelEvaluatorHeaderActions.batchProgress.failed > 0 && (
+                            <>
+                              {' '}
+                              <span className="text-red-400">
+                                {modelEvaluatorHeaderActions.batchProgress.failed} 失敗
+                              </span>
+                            </>
+                          )}
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      );
+    }
+
     if (activeTab === 'adapter-config') {
       return (
         <div className="space-y-4">
@@ -1287,41 +1993,7 @@ export default function AIServiceSettingsPage() {
                 可針對每家 Adapter 設定測試 Prompt、上傳測試文件並控制執行；Prompt 可自行編輯或從 Prompt Management 載入。
               </p>
             </div>
-            <div className="min-w-0 flex-1 border-t border-border-default pt-4 lg:max-w-md lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0">
-              <div className="flex items-start justify-between gap-2">
-                <p className="text-xs font-semibold text-text-primary">最近測試錯誤／警告</p>
-                <button
-                  type="button"
-                  onClick={() => setAdapterRunNotices([])}
-                  disabled={adapterRunNotices.length === 0}
-                  className="shrink-0 rounded px-2 py-0.5 text-[11px] font-medium text-text-muted transition hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  清除
-                </button>
-              </div>
-              {adapterRunNotices.length === 0 ? (
-                <p className="mt-2 text-[11px] leading-relaxed text-text-muted">
-                  尚無紀錄。啟動失敗、遠端操作失敗，或單次執行結束後評價為「不及格／模型不正確」時會列在此，方便對照（關閉彈窗後仍可回看）。
-                </p>
-              ) : (
-                <ul className="mt-2 max-h-36 space-y-2 overflow-y-auto pr-0.5">
-                  {adapterRunNotices.map((n) => (
-                    <li
-                      key={n.id}
-                      className={`rounded-md border px-2.5 py-1.5 text-[11px] leading-snug ${
-                        n.severity === 'error'
-                          ? 'border-rose-200 bg-rose-50/80 text-rose-900'
-                          : 'border-amber-200 bg-amber-50/80 text-amber-950'
-                      }`}
-                    >
-                      <span className="font-medium text-text-secondary">{formatAdapterNoticeTime(n.at)}</span>
-                      <span className="text-text-muted"> · {n.adapterLabel}</span>
-                      <p className="mt-0.5 break-words">{n.message}</p>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
+            {renderAdapterRunNoticesColumn()}
           </div>
 
           <EnhancedTable<AdapterConfigTableRow>
@@ -1362,6 +2034,95 @@ export default function AIServiceSettingsPage() {
                 )}
               </button>
             }
+          />
+        </div>
+      );
+    }
+    if (activeTab === 'http-adapter-config') {
+      const { cli, http } = adapterCompareSummary;
+      return (
+        <div className="space-y-4">
+          <div className="flex flex-col gap-4 rounded-base border border-dashed border-border-default bg-bg-secondary p-4 lg:flex-row lg:items-stretch">
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-semibold text-text-primary">CLI vs HTTP 比較摘要（最近一輪）</p>
+              <div className="mt-3 grid gap-2 text-[11px] text-text-secondary sm:grid-cols-2 lg:grid-cols-4">
+                <p>CLI P50/P95: <span className="font-mono">{Math.round(cli.p50Latency ?? 0)}/{Math.round(cli.p95Latency ?? 0)} ms</span></p>
+                <p>HTTP P50/P95: <span className="font-mono">{Math.round(http.p50Latency ?? 0)}/{Math.round(http.p95Latency ?? 0)} ms</span></p>
+                <p>CLI 成功率: <span className="font-mono">{Math.round(cli.successRate * 100)}%</span></p>
+                <p>HTTP 成功率: <span className="font-mono">{Math.round(http.successRate * 100)}%</span></p>
+                <p>CLI Timeout: <span className="font-mono">{Math.round(cli.timeoutRate * 100)}%</span></p>
+                <p>HTTP Timeout: <span className="font-mono">{Math.round(http.timeoutRate * 100)}%</span></p>
+                <p>CLI 5xx: <span className="font-mono">{Math.round(cli.serverErrRate * 100)}%</span></p>
+                <p>HTTP 5xx: <span className="font-mono">{Math.round(http.serverErrRate * 100)}%</span></p>
+                <p>CLI 平均重試: <span className="font-mono">{cli.avgRetry.toFixed(2)}</span></p>
+                <p>HTTP 平均重試: <span className="font-mono">{http.avgRetry.toFixed(2)}</span></p>
+                <p>CLI P50 TTFT: <span className="font-mono">{Math.round(cli.p50Ttft ?? 0)} ms</span></p>
+                <p>HTTP P50 TTFT: <span className="font-mono">{Math.round(http.p50Ttft ?? 0)} ms</span></p>
+              </div>
+            </div>
+            {renderAdapterRunNoticesColumn()}
+          </div>
+          <EnhancedTable<AdapterConfigTableRow>
+            tableId={HTTP_ADAPTER_CONFIG_TABLE_ID}
+            columns={httpAdapterConfigTableColumns}
+            data={httpAdapterTableRows}
+            initialWidths={[...HTTP_ADAPTER_CONFIG_TABLE_INITIAL_WIDTHS]}
+            minWidth={HTTP_ADAPTER_CONFIG_TABLE_MIN_WIDTH_PX}
+            stretchToContainer={false}
+            getSearchValue={getAdapterConfigSearchValue}
+            getCategoryValue={getAdapterConfigCategoryValue}
+            extraToolbar={
+              <button
+                type="button"
+                onClick={() => {
+                  void runAllHttpAdapters();
+                }}
+                disabled={httpBulkStarting}
+                className="inline-flex h-8 items-center gap-1.5 rounded-md bg-emerald-600 px-3 text-xs font-semibold text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+                title={
+                  httpBulkStarting
+                    ? '一鍵啟動全部 HTTP Adapter 測試（進行中）'
+                    : '一鍵啟動全部 HTTP Adapter 測試'
+                }
+                aria-busy={httpBulkStarting}
+              >
+                {httpBulkStarting && httpBulkRunStartedAtMs != null ? (
+                  <>
+                    <Loader2 size={14} className="shrink-0 animate-spin" aria-hidden />
+                    <BulkRunElapsed startMs={httpBulkRunStartedAtMs} />
+                    <span>全測中</span>
+                  </>
+                ) : (
+                  <>
+                    <Play size={14} aria-hidden />
+                    全測
+                  </>
+                )}
+              </button>
+            }
+          />
+        </div>
+      );
+    }
+
+    if (activeTab === 'model-router') {
+      return (
+        <div className="space-y-4">
+          <div className="rounded-base border border-dashed border-border-default bg-bg-secondary p-4">
+            <p className="text-xs font-semibold text-text-primary">Model Router 規劃表</p>
+            <p className="mt-1 text-xs text-text-muted">
+              用於整理前面 Adapter 的模型路由策略，包含主模型、fallback chain、觸發條件與狀態，便於規劃像「謄本解析 AI 助手」這類實戰路由方案。
+            </p>
+          </div>
+          <EnhancedTable<ModelRouterRow>
+            tableId="ai-settings-model-router-v1"
+            columns={modelRouterColumns}
+            data={MODEL_ROUTER_ROWS}
+            initialWidths={[...MODEL_ROUTER_TABLE_INITIAL_WIDTHS]}
+            minWidth={MODEL_ROUTER_TABLE_MIN_WIDTH_PX}
+            stretchToContainer={false}
+            getSearchValue={getModelRouterSearchValue}
+            getCategoryValue={getModelRouterCategoryValue}
           />
         </div>
       );
@@ -1602,7 +2363,7 @@ export default function AIServiceSettingsPage() {
         <div className="flex items-center justify-between gap-2">
           <div className="flex flex-wrap items-center gap-2 gap-y-1 min-w-0">
             {React.createElement(currentTab.icon, { size: 18, className: 'text-accent shrink-0' })}
-            {activeTab !== 'adapter-config' && (
+            {activeTab !== 'adapter-config' && activeTab !== 'http-adapter-config' && (
               <div className="min-w-0">
                 <h2 className="text-sm font-semibold text-text-primary">{currentTab.label}</h2>
                 {currentTab.description && (
@@ -1610,7 +2371,11 @@ export default function AIServiceSettingsPage() {
                 )}
               </div>
             )}
-            {activeTab !== 'llm-leaderboard' && activeTab !== 'adapter-config' && (
+            {activeTab !== 'llm-leaderboard' &&
+            activeTab !== 'evaluations-global' &&
+            activeTab !== 'adapter-config' &&
+            activeTab !== 'http-adapter-config' &&
+            activeTab !== 'model-router' && (
             <div className="flex items-center gap-2 shrink-0">
               <button
                 type="button"
@@ -1623,18 +2388,6 @@ export default function AIServiceSettingsPage() {
               >
                 <BookMarked size={14} className="text-text-muted" />
                 <span>Prompt 管理</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  if (typeof window === 'undefined') return;
-                  window.open('/superadmin/settings/evaluations-global-test', '_blank', 'noopener,noreferrer');
-                }}
-                className="inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-xs font-medium transition-colors whitespace-nowrap shrink-0 bg-bg-secondary text-text-secondary hover:text-text-primary hover:bg-bg-tertiary border border-border-subtle"
-                title="另開分頁開啟 AI 模型全域評測頁面"
-              >
-                <FlaskConical size={14} className="text-text-muted" />
-                <span>AI 模型全域評測</span>
               </button>
               {activeTab !== 'keys' && (
                 <>
@@ -1834,6 +2587,11 @@ export default function AIServiceSettingsPage() {
       fixedContent={fixedBlock}
       contentFullHeight
     >
+      {httpBulkToast && (
+        <div className="fixed right-6 top-24 z-[120] max-w-[520px] rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs font-medium text-emerald-900 shadow-lg">
+          {httpBulkToast}
+        </div>
+      )}
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <div className="min-w-0 w-full flex-1 overflow-y-auto overflow-x-hidden px-2 py-3 sm:px-4 lg:px-6 lg:py-4">
         <section className="min-w-0 space-y-4">
@@ -1861,7 +2619,7 @@ export default function AIServiceSettingsPage() {
               </p>
               <ol className="list-decimal list-inside space-y-1 text-xs text-text-secondary">
                 <li>在「API 金鑰管理」新增各提供商的 API 金鑰；可用「驗證金鑰」確認可用性並取得可選模型清單。</li>
-                <li>前往「AI 模型全域評測」頁勾選要納入候選的模型（可測試連線）。</li>
+                <li>切換底部分頁「AI 模型全域評測」，於工作表中勾選要納入候選的模型（可測試連線）。</li>
               </ol>
             </div>
           </div>
@@ -1874,6 +2632,15 @@ export default function AIServiceSettingsPage() {
           onTabChange={handleSheetTabChange}
         />
       </div>
+      {showPromptManager && (
+        <PromptManagerModal
+          onClose={() => setShowPromptManager(false)}
+          onLoad={(content) => {
+            setGlobalTestPrompt(content);
+            setShowPromptManager(false);
+          }}
+        />
+      )}
     </DashboardLayout>
   );
 }

--- a/apps/superadmin/components/ai-settings/ApiKeyManager.tsx
+++ b/apps/superadmin/components/ai-settings/ApiKeyManager.tsx
@@ -9,12 +9,10 @@ import { Button } from '@/components/ui/Button';
 import { AI_PROVIDERS, type AIProvider, type AIProviderInfo } from '@/lib/ai-providers';
 import { maskApiKey } from '@/lib/crypto';
 import { parseEnvForAIKeys, SUPPORTED_AI_ENV_KEY_NAMES } from '@/lib/parse-env-keys';
-import type { SavedKey, SavedModel, KeyValidationResult } from '@/lib/hooks/useAISettings';
+import type { SavedKey, KeyValidationResult } from '@/lib/hooks/useAISettings';
 
 interface ApiKeyManagerProps {
   savedKeys: SavedKey[];
-  /** 來自「模型費用說明」的已選模型，用於在未驗證時顯示已選模型（系統有持久化） */
-  savedModels?: SavedModel[];
   /** 全部驗證完成後各 key 的結果，供每張 card 直接顯示 Available models */
   validateAllResultsByKeyId?: Record<string, KeyValidationResult>;
   /** options.skipRefresh: 批量導入時傳 true，由呼叫端在全部完成後自行重整，避免畫面閃爍 */
@@ -37,8 +35,6 @@ export interface ApiKeyManagerHandle {
 interface ProviderKeyRowProps {
   provider: AIProviderInfo;
   savedKey?: SavedKey;
-  /** 該 provider 在 DB 的已選模型（唯讀顯示；實際選擇請至「AI 模型全域評測」頁） */
-  providerSavedModels?: SavedModel[];
   /** 全部驗證完成後傳入的該 key 結果，用於直接顯示 Available models 無需再按「驗證金鑰」 */
   validationResultFromValidateAll?: KeyValidationResult;
   onSave: (provider: AIProvider, rawKey: string) => Promise<void>;
@@ -47,7 +43,7 @@ interface ProviderKeyRowProps {
   onRevealKey: (keyId: string) => Promise<{ plaintext: string; ttlSeconds: number }>;
 }
 
-function ProviderKeyRow({ provider, savedKey, providerSavedModels = [], validationResultFromValidateAll, onSave, onDelete, onValidate, onRevealKey }: ProviderKeyRowProps) {
+function ProviderKeyRow({ provider, savedKey, validationResultFromValidateAll, onSave, onDelete, onValidate, onRevealKey }: ProviderKeyRowProps) {
   const [inputValue, setInputValue] = useState('');
   const [showKey, setShowKey] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -378,28 +374,6 @@ function ProviderKeyRow({ provider, savedKey, providerSavedModels = [], validati
         <span>Base URL: <code className="text-text-secondary">{provider.baseUrl}</code></span>
       </div>
 
-      {/* 已選模型（唯讀；選擇/變更請至「AI 模型全域評測」頁） */}
-      {savedKey && providerSavedModels.length > 0 && (
-        <div className="mt-2 space-y-0.5 text-[11px] text-text-muted">
-          <div className="flex items-center gap-2">
-            <span className="shrink-0 font-medium text-text-secondary">已選模型：</span>
-            <span className="font-mono text-[10px] text-text-primary">
-              {providerSavedModels.map(m => m.model_id).join('、')}
-            </span>
-          </div>
-          <p className="text-[10px] text-text-muted">
-            選擇或變更模型請至「AI 模型全域評測」頁。
-          </p>
-        </div>
-      )}
-      {savedKey && providerSavedModels.length === 0 && (
-        <div className="mt-2 space-y-0.5 text-[11px] text-text-muted">
-          <p className="text-[10px] text-text-muted">
-            尚未選擇模型 — 前往「AI 模型全域評測」頁選擇。
-          </p>
-        </div>
-      )}
-
       {/* 驗證後可用模型清單（顯示 API 回傳的完整模型列表） */}
       {displayResult?.valid && Array.isArray(displayResult.availableModels) && displayResult.availableModels.length > 0 && (
         <div className="mt-2 text-[11px] text-text-muted">
@@ -442,7 +416,6 @@ function ProviderKeyRow({ provider, savedKey, providerSavedModels = [], validati
 
 const ApiKeyManagerInner = ({
   savedKeys,
-  savedModels = [],
   validateAllResultsByKeyId,
   onSave,
   onDelete,
@@ -587,13 +560,11 @@ ref: React.Ref<ApiKeyManagerHandle>) => {
       <div className="space-y-3">
         {AI_PROVIDERS.map(provider => {
           const savedKey = savedKeys.find(k => k.provider === provider.id);
-          const providerSavedModels = savedModels.filter(m => m.provider === provider.id);
           return (
             <ProviderKeyRow
               key={provider.id}
               provider={provider}
               savedKey={savedKey}
-              providerSavedModels={providerSavedModels}
               validationResultFromValidateAll={savedKey ? validateAllResultsByKeyId?.[savedKey.id] : undefined}
               onSave={onSave}
               onDelete={onDelete}

--- a/apps/superadmin/lib/__tests__/adapter-config-fallback-models.test.ts
+++ b/apps/superadmin/lib/__tests__/adapter-config-fallback-models.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Offline drift check for adapter-config fallbackModels.
+ *
+ * Each adapter row declares a fallback chain used by both CLI and HTTP modes on the
+ * Api Key & Model Setting page. Every primary and fallback slug must appear in the
+ * provider's validated model list (`ai_key_validation_cache.available_models`).
+ *
+ * CACHE_SNAPSHOT below is a hand-maintained copy of the latest validation output,
+ * trimmed to the slugs that adapter-config actually references. Refresh it whenever
+ * fallback chains change or keys are re-validated with new model catalogs.
+ *
+ * Snapshot captured: 2026-04-21 (validated_at 2026-04-20T08:02:xx)
+ */
+
+import {
+  ADAPTER_CONFIG_ITEMS,
+  type AdapterConfigItem,
+  type AdapterProvider,
+} from '@/lib/adapter-config';
+import { openCodeZenChatModelId } from '@/lib/ai-key-validation/kilo-opencode-zen';
+
+type CacheProvider = 'anthropic' | 'gemini' | 'openai' | 'kilo' | 'opencode';
+
+const CACHE_SNAPSHOT: Record<CacheProvider, readonly string[]> = {
+  anthropic: [
+    'claude-opus-4-7',
+    'claude-sonnet-4-6',
+    'claude-opus-4-6',
+    'claude-opus-4-5-20251101',
+    'claude-haiku-4-5-20251001',
+    'claude-sonnet-4-5-20250929',
+    'claude-opus-4-1-20250805',
+    'claude-opus-4-20250514',
+    'claude-sonnet-4-20250514',
+    'claude-3-haiku-20240307',
+  ],
+  gemini: [
+    'gemini-3.1-pro-preview',
+    'gemini-3-pro-preview',
+    'gemini-3-flash-preview',
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
+  ],
+  openai: [
+    'gpt-5.4-pro-2026-03-05',
+    'gpt-5.4',
+    'gpt-5.4-mini',
+    'gpt-5.3-codex',
+    'gpt-5.2-codex',
+    'gpt-5.1-codex',
+    'gpt-5-codex',
+    'gpt-4o-mini',
+  ],
+  kilo: [
+    'minimax/minimax-m2.5',
+    'minimax/minimax-m2.1',
+    'minimax/minimax-m2',
+    'minimax/minimax-m1',
+    'qwen/qwen3.6-plus',
+    'qwen/qwen3.5-plus-02-15',
+    'qwen/qwen3-max',
+    'qwen/qwen-plus',
+  ],
+  opencode: [
+    'glm-5.1',
+    'glm-5',
+    'glm-4.7',
+    'glm-4.6',
+    'minimax-m2.5',
+    'minimax-m2.1',
+    'kimi-k2.5',
+    'kimi-k2-thinking',
+    'kimi-k2',
+    'qwen3.6-plus',
+    'qwen3.5-plus',
+  ],
+};
+
+/**
+ * Mirror the runtime translation that adapter-runs/route.ts applies before hitting the
+ * provider's API: strip `openrouter/` for kilo, use openCodeZenChatModelId for opencode.
+ * Anthropic/gemini/openai pass through untouched.
+ */
+function translateForCache(
+  provider: AdapterProvider,
+  model: string,
+): { cacheProvider: CacheProvider; cacheId: string } {
+  switch (provider) {
+    case 'claude':
+      return { cacheProvider: 'anthropic', cacheId: model };
+    case 'gemini':
+      return { cacheProvider: 'gemini', cacheId: model };
+    case 'codex':
+      return { cacheProvider: 'openai', cacheId: model };
+    case 'kilo': {
+      const stripped = model.startsWith('openrouter/')
+        ? model.slice('openrouter/'.length)
+        : model;
+      return { cacheProvider: 'kilo', cacheId: stripped };
+    }
+    case 'opencode':
+      return { cacheProvider: 'opencode', cacheId: openCodeZenChatModelId(model) };
+  }
+}
+
+describe('adapter-config fallbackModels (offline drift check)', () => {
+  it('defines fallbackModels on every adapter row', () => {
+    for (const item of ADAPTER_CONFIG_ITEMS) {
+      expect(Array.isArray(item.fallbackModels)).toBe(true);
+    }
+  });
+
+  it('never lists a primary model as its own fallback', () => {
+    for (const item of ADAPTER_CONFIG_ITEMS) {
+      expect(item.fallbackModels).not.toContain(item.model);
+    }
+  });
+
+  it('keeps fallback chains free of duplicates', () => {
+    for (const item of ADAPTER_CONFIG_ITEMS) {
+      const set = new Set(item.fallbackModels);
+      expect(set.size).toBe(item.fallbackModels.length);
+    }
+  });
+
+  describe.each(ADAPTER_CONFIG_ITEMS)(
+    '$id ($provider)',
+    (item: AdapterConfigItem) => {
+      it('primary model appears in cache snapshot', () => {
+        const { cacheProvider, cacheId } = translateForCache(item.provider, item.model);
+        expect(CACHE_SNAPSHOT[cacheProvider]).toContain(cacheId);
+      });
+
+      it.each(item.fallbackModels)(
+        'fallback %s appears in cache snapshot',
+        (fallback: string) => {
+          const { cacheProvider, cacheId } = translateForCache(item.provider, fallback);
+          expect(CACHE_SNAPSHOT[cacheProvider]).toContain(cacheId);
+        },
+      );
+    },
+  );
+});

--- a/apps/superadmin/lib/adapter-config.ts
+++ b/apps/superadmin/lib/adapter-config.ts
@@ -8,6 +8,13 @@ export type AdapterConfigItem = {
   optionLabel: string;
   provider: AdapterProvider;
   model: string;
+  /**
+   * Ordered downgrade chain tried on primary-model failure. Each fallback is attempted
+   * via the same path (CLI → CLI, HTTP → HTTP) so speed/stability comparisons stay honest.
+   * Values must appear in the provider's validated model list (ai_key_validation_cache) —
+   * enforced offline by unit test `adapter-config-fallback-models.test.ts`.
+   */
+  fallbackModels: string[];
   status: AdapterLifecycleStatus;
   useCases: string[];
   cliCommandTemplate: string;
@@ -21,6 +28,16 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
     optionLabel: 'Claude CLI + Opus 4.7',
     provider: 'claude',
     model: 'claude-opus-4-7',
+    fallbackModels: [
+      'claude-sonnet-4-6',
+      'claude-opus-4-6',
+      'claude-opus-4-5-20251101',
+      'claude-haiku-4-5-20251001',
+      'claude-sonnet-4-5-20250929',
+      'claude-opus-4-1-20250805',
+      'claude-opus-4-20250514',
+      'claude-sonnet-4-20250514',
+    ],
     status: 'planned',
     useCases: ['complex-architecture', 'deep-review'],
     cliCommandTemplate: 'claude -p "<prompt>"',
@@ -32,6 +49,15 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
     optionLabel: 'Claude CLI + Sonnet 4.6',
     provider: 'claude',
     model: 'claude-sonnet-4-6',
+    fallbackModels: [
+      'claude-opus-4-6',
+      'claude-opus-4-5-20251101',
+      'claude-haiku-4-5-20251001',
+      'claude-sonnet-4-5-20250929',
+      'claude-opus-4-1-20250805',
+      'claude-opus-4-20250514',
+      'claude-sonnet-4-20250514',
+    ],
     status: 'planned',
     useCases: ['general-dev', 'reasoning', 'spec-writing'],
     cliCommandTemplate: 'claude -p "<prompt>"',
@@ -43,6 +69,14 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
     optionLabel: 'Claude CLI + Opus 4.6',
     provider: 'claude',
     model: 'claude-opus-4-6',
+    fallbackModels: [
+      'claude-opus-4-5-20251101',
+      'claude-haiku-4-5-20251001',
+      'claude-sonnet-4-5-20250929',
+      'claude-opus-4-1-20250805',
+      'claude-opus-4-20250514',
+      'claude-sonnet-4-20250514',
+    ],
     status: 'planned',
     useCases: ['complex-architecture', 'deep-review'],
     cliCommandTemplate: 'claude -p "<prompt>"',
@@ -54,6 +88,12 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
     optionLabel: 'Gemini CLI + Gemini 3.1 Pro Preview',
     provider: 'gemini',
     model: 'gemini-3.1-pro-preview',
+    fallbackModels: [
+      'gemini-3-pro-preview',
+      'gemini-3-flash-preview',
+      'gemini-2.5-pro',
+      'gemini-2.5-flash',
+    ],
     status: 'planned',
     useCases: ['multimodal', 'large-context'],
     cliCommandTemplate: 'agent -p "<prompt>"',
@@ -66,6 +106,14 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
     provider: 'codex',
     /** OpenAI 帳號可用模型須與驗證快取一致；codex CLI 不支援舊版 xhigh slug */
     model: 'gpt-5.4-pro-2026-03-05',
+    fallbackModels: [
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'gpt-5.3-codex',
+      'gpt-5.2-codex',
+      'gpt-5.1-codex',
+      'gpt-5-codex',
+    ],
     status: 'planned',
     useCases: ['code-generation', 'large-refactor'],
     cliCommandTemplate: 'codex exec "<prompt>"',
@@ -84,6 +132,12 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
      * adapter table row "codex_local".
      */
     model: 'gpt-5.3-codex',
+    fallbackModels: [
+      'gpt-5.2-codex',
+      'gpt-5.1-codex',
+      'gpt-5-codex',
+      'gpt-4o-mini',
+    ],
     status: 'planned',
     useCases: ['code-fix', 'test-authoring'],
     cliCommandTemplate: 'codex exec "<prompt>"',
@@ -100,19 +154,13 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
     optionLabel: 'Kilo CLI + MiniMax M2.7（實際 M2.5）',
     provider: 'kilo',
     model: 'openrouter/minimax/minimax-m2.5',
+    fallbackModels: [
+      'openrouter/minimax/minimax-m2.1',
+      'openrouter/minimax/minimax-m2',
+      'openrouter/minimax/minimax-m1',
+    ],
     status: 'planned',
     useCases: ['cost-optimized-batch', 'automation'],
-    cliCommandTemplate: 'kilo run "<prompt>"',
-    docsPath: 'docs/Adapter CLIs/Kilo_CLI.md',
-  },
-  {
-    id: 'kilo-dola-seed-2-0-pro',
-    optionValue: 'kilo-dola-seed-2-0-pro',
-    optionLabel: 'Kilo CLI + Dola Seed 2.0 Pro',
-    provider: 'kilo',
-    model: 'dola-seed-2.0-pro',
-    status: 'planned',
-    useCases: ['analysis', 'batch-planning'],
     cliCommandTemplate: 'kilo run "<prompt>"',
     docsPath: 'docs/Adapter CLIs/Kilo_CLI.md',
   },
@@ -121,7 +169,13 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
     optionValue: 'kilo-qwen-3-6-plus',
     optionLabel: 'Kilo CLI + Qwen 3.6 Plus',
     provider: 'kilo',
-    model: 'qwen/qwen3.6-plus',
+    /** 見 .claude/rules/backend/ai-adapter.md：kilo 須 `openrouter/` 前綴 */
+    model: 'openrouter/qwen/qwen3.6-plus',
+    fallbackModels: [
+      'openrouter/qwen/qwen3.5-plus-02-15',
+      'openrouter/qwen/qwen3-max',
+      'openrouter/qwen/qwen-plus',
+    ],
     status: 'planned',
     useCases: ['chinese-content', 'cost-balanced'],
     cliCommandTemplate: 'kilo run "<prompt>"',
@@ -132,7 +186,12 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
     optionValue: 'opencode-kimi-k2-5',
     optionLabel: 'OpenCode CLI + Kimi K2.5',
     provider: 'opencode',
-    model: 'moonshotai/kimi-k2.5',
+    /** OpenRouter id `moonshotai/kimi-k2.5`；HTTP 會剝除 `openrouter/` 再呼叫 API */
+    model: 'openrouter/moonshotai/kimi-k2.5',
+    fallbackModels: [
+      'openrouter/moonshotai/kimi-k2-thinking',
+      'openrouter/moonshotai/kimi-k2',
+    ],
     status: 'planned',
     useCases: ['long-context', 'code-assistant'],
     cliCommandTemplate: 'opencode run "<prompt>"',
@@ -144,6 +203,11 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
     optionLabel: 'OpenCode CLI + GLM 5.1',
     provider: 'opencode',
     model: 'z-ai/glm-5.1',
+    fallbackModels: [
+      'z-ai/glm-5',
+      'z-ai/glm-4.7',
+      'z-ai/glm-4.6',
+    ],
     status: 'planned',
     useCases: ['multilingual', 'code-assistant'],
     cliCommandTemplate: 'opencode run "<prompt>"',
@@ -161,6 +225,9 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
     optionLabel: 'OpenCode CLI + MiniMax M2.7（實際 M2.5）',
     provider: 'opencode',
     model: 'openrouter/minimax/minimax-m2.5',
+    fallbackModels: [
+      'openrouter/minimax/minimax-m2.1',
+    ],
     status: 'planned',
     useCases: ['cost-optimized-batch', 'tool-calling'],
     cliCommandTemplate: 'opencode run "<prompt>"',
@@ -171,7 +238,10 @@ export const ADAPTER_CONFIG_ITEMS: AdapterConfigItem[] = [
     optionValue: 'opencode-qwen-3-6-plus',
     optionLabel: 'OpenCode CLI + Qwen 3.6 Plus',
     provider: 'opencode',
-    model: 'qwen/qwen3.6-plus',
+    model: 'openrouter/qwen/qwen3.6-plus',
+    fallbackModels: [
+      'openrouter/qwen/qwen3.5-plus',
+    ],
     status: 'planned',
     useCases: ['chinese-content', 'code-assistant'],
     cliCommandTemplate: 'opencode run "<prompt>"',

--- a/apps/superadmin/lib/adapter-runs/__tests__/adapter-run-meta-lines.test.ts
+++ b/apps/superadmin/lib/adapter-runs/__tests__/adapter-run-meta-lines.test.ts
@@ -1,0 +1,26 @@
+import {
+  isAdapterRunMetaContent,
+  isAdapterRunMetaLine,
+  stripAdapterLogTimestamp,
+} from '@/lib/adapter-runs/adapter-run-meta-lines';
+
+describe('adapter-run-meta-lines', () => {
+  it('strips leading timestamp', () => {
+    expect(stripAdapterLogTimestamp('[07:42:40] 選定模型：x')).toBe('選定模型：x');
+  });
+
+  it('marks injected adapter bookkeeping as meta', () => {
+    expect(isAdapterRunMetaContent('選定模型：openrouter/qwen/qwen3.6-plus')).toBe(true);
+    expect(isAdapterRunMetaContent('Fallback 模型解析：openrouter/qwen/qwen3.6-plus（requested）')).toBe(true);
+    expect(isAdapterRunMetaContent('API Key 來源：ANTHROPIC_API_KEY:supabase')).toBe(true);
+  });
+
+  it('does not mark real assistant text as meta', () => {
+    expect(isAdapterRunMetaContent('我是通義千問 Qwen，由阿里巴巴訓練。')).toBe(false);
+  });
+
+  it('classifies full log lines with timestamps', () => {
+    expect(isAdapterRunMetaLine('[07:42:40] Fallback 模型解析：x（requested）')).toBe(true);
+    expect(isAdapterRunMetaLine('[07:42:40] 你好，我是 Qwen。')).toBe(false);
+  });
+});

--- a/apps/superadmin/lib/adapter-runs/__tests__/extract-chat-completion-text.test.ts
+++ b/apps/superadmin/lib/adapter-runs/__tests__/extract-chat-completion-text.test.ts
@@ -24,6 +24,21 @@ describe('extractChatCompletionAssistantText', () => {
     ).toBe('我是由 Moonshot 開發的 Kimi 模型。');
   });
 
+  it('returns message.reasoning.text when reasoning is an object', () => {
+    expect(
+      extractChatCompletionAssistantText({
+        choices: [
+          {
+            message: {
+              content: null,
+              reasoning: { text: 'nested reasoning body' },
+            },
+          },
+        ],
+      })
+    ).toBe('nested reasoning body');
+  });
+
   it('prefers content over reasoning when both exist', () => {
     expect(
       extractChatCompletionAssistantText({

--- a/apps/superadmin/lib/adapter-runs/__tests__/extract-openai-responses-text.test.ts
+++ b/apps/superadmin/lib/adapter-runs/__tests__/extract-openai-responses-text.test.ts
@@ -1,0 +1,29 @@
+import { extractOpenAiResponsesOutputText } from '../extract-openai-responses-text';
+
+describe('extractOpenAiResponsesOutputText', () => {
+  it('prefers output[].content[].text over empty output_text', () => {
+    const data = {
+      output_text: '',
+      output: [
+        {
+          type: 'message',
+          content: [{ type: 'output_text', text: 'Hello from nested output.' }],
+        },
+      ],
+    };
+    expect(extractOpenAiResponsesOutputText(data)).toBe('Hello from nested output.');
+  });
+
+  it('falls back to top-level output_text', () => {
+    expect(
+      extractOpenAiResponsesOutputText({
+        output_text: 'Only here.',
+        output: [],
+      }),
+    ).toBe('Only here.');
+  });
+
+  it('returns empty string when neither is present', () => {
+    expect(extractOpenAiResponsesOutputText({ output: [{ type: 'message', content: [] }] })).toBe('');
+  });
+});

--- a/apps/superadmin/lib/adapter-runs/adapter-run-meta-lines.ts
+++ b/apps/superadmin/lib/adapter-runs/adapter-run-meta-lines.ts
@@ -1,0 +1,50 @@
+/**
+ * Adapter-runs injects bookkeeping lines into `logs`; OpenCode/Kilo CLIs may also
+ * print binding/diagnostic lines. These must not count as model output for grading
+ * or for {@link deriveResultFromLogs} in adapter-runs/route.ts.
+ */
+
+export function stripAdapterLogTimestamp(line: string): string {
+  return line.replace(/^\[\d{2}:\d{2}:\d{2}\]\s*/, '').trim();
+}
+
+/** True when `coreLine` is already timestamp-stripped (and optionally `[stderr]` stripped). */
+export function isAdapterRunMetaContent(coreLine: string): boolean {
+  const s = coreLine.replace(/^\[stderr\]\s*/i, '').trim();
+  if (!s) return true;
+  const patterns: RegExp[] = [
+    /^啟動命令：/,
+    /^API Key 來源：/,
+    /^選定模型：/,
+    /^Fallback 模型解析：/,
+    /^降級鏈（/,
+    /^掛載測試檔：/,
+    /^CLI 啟動：/,
+    /^CLI primary 成功/,
+    /^CLI 降級成功/,
+    /^CLI 降級鏈已耗盡/,
+    /^HTTP 執行中：/,
+    /^HTTP 回應成功/,
+    /^HTTP primary 成功/,
+    /^HTTP 降級成功/,
+    /^HTTP 降級鏈已耗盡/,
+    /^HTTP 失敗：/,
+    /^降級到 /,
+    /^程序已結束\s*\(/,
+    /^偵測到 .*CLI 失敗/i,
+    /^切換到 API fallback/i,
+    /^API fallback 成功/i,
+    /^OpenAI-compatible fallback 失敗/i,
+    /^Anthropic API fallback/i,
+    /^Gemini API fallback/i,
+    /^binding model:/i,
+  ];
+  return patterns.some((re) => re.test(s));
+}
+
+/** Full log line as stored in `run.logs` (may include `[HH:MM:SS]` prefix). */
+export function isAdapterRunMetaLine(line: string): boolean {
+  const withoutTs = stripAdapterLogTimestamp(line);
+  const core = withoutTs.replace(/^\[stderr\]\s*/i, '').trim();
+  return isAdapterRunMetaContent(core);
+}

--- a/apps/superadmin/lib/adapter-runs/extract-chat-completion-text.ts
+++ b/apps/superadmin/lib/adapter-runs/extract-chat-completion-text.ts
@@ -47,6 +47,10 @@ export function extractChatCompletionAssistantText(data: unknown): string {
     const t = msg.reasoning.trim();
     if (t) return t;
   }
+  if (msg.reasoning && typeof msg.reasoning === 'object' && !Array.isArray(msg.reasoning)) {
+    const r = msg.reasoning as Record<string, unknown>;
+    if (typeof r.text === 'string' && r.text.trim()) return r.text.trim();
+  }
 
   if (typeof msg.refusal === 'string') {
     const t = msg.refusal.trim();

--- a/apps/superadmin/lib/adapter-runs/extract-openai-responses-text.ts
+++ b/apps/superadmin/lib/adapter-runs/extract-openai-responses-text.ts
@@ -1,0 +1,29 @@
+/**
+ * OpenAI `POST /v1/responses` JSON: assistant text often lives in
+ * `output[].content[].text`; `output_text` is not always populated.
+ *
+ * Mirrors the extraction used in `model-research/generate/route.ts` so
+ * adapter HTTP tests do not show "成功但無輸出" when the API returned text.
+ */
+export function extractOpenAiResponsesOutputText(data: unknown): string {
+  const root = data as {
+    output?: Array<{
+      type?: string;
+      content?: Array<{ type?: string; text?: string }>;
+    }>;
+    output_text?: string;
+  };
+  let text = '';
+  for (const item of root.output ?? []) {
+    if (!Array.isArray(item.content)) continue;
+    for (const block of item.content) {
+      if (typeof block?.text === 'string') text += block.text;
+    }
+  }
+  const trimmed = text.trim();
+  if (trimmed) return trimmed;
+  if (typeof root.output_text === 'string' && root.output_text.trim()) {
+    return root.output_text.trim();
+  }
+  return '';
+}

--- a/apps/superadmin/lib/ai-key-validation/__tests__/kilo-opencode-zen.test.ts
+++ b/apps/superadmin/lib/ai-key-validation/__tests__/kilo-opencode-zen.test.ts
@@ -1,9 +1,29 @@
 import {
   KILO_GATEWAY_BASE,
   OPENCODE_ZEN_MODELS_URL,
+  openCodeZenChatModelId,
   validateKiloGatewayKey,
   validateOpenCodeZenKey,
 } from '@/lib/ai-key-validation/kilo-opencode-zen';
+
+describe('openCodeZenChatModelId', () => {
+  it('maps OpenRouter Qwen 3.6 Plus to Zen catalog id', () => {
+    expect(openCodeZenChatModelId('openrouter/qwen/qwen3.6-plus')).toBe('qwen3.6-plus');
+    expect(openCodeZenChatModelId('qwen/qwen3.6-plus')).toBe('qwen3.6-plus');
+  });
+
+  it('maps Kimi / MiniMax / GLM OpenRouter ids to Zen slugs', () => {
+    expect(openCodeZenChatModelId('openrouter/moonshotai/kimi-k2.5')).toBe('kimi-k2.5');
+    expect(openCodeZenChatModelId('openrouter/minimax/minimax-m2.5')).toBe('minimax-m2.5');
+    expect(openCodeZenChatModelId('openrouter/minimax/minimax-m2.7')).toBe('minimax-m2.5');
+    expect(openCodeZenChatModelId('z-ai/glm-5.1')).toBe('glm-5.1');
+  });
+
+  it('passes through Zen-native ids unchanged', () => {
+    expect(openCodeZenChatModelId('qwen3.6-plus')).toBe('qwen3.6-plus');
+    expect(openCodeZenChatModelId('kimi-k2.5')).toBe('kimi-k2.5');
+  });
+});
 
 describe('validateOpenCodeZenKey', () => {
   it('should return invalid when API key is empty', async () => {

--- a/apps/superadmin/lib/ai-key-validation/kilo-opencode-zen.ts
+++ b/apps/superadmin/lib/ai-key-validation/kilo-opencode-zen.ts
@@ -9,6 +9,43 @@ export const OPENCODE_ZEN_BASE = 'https://opencode.ai/zen/v1';
 export const OPENCODE_ZEN_MODELS_URL = `${OPENCODE_ZEN_BASE}/models`;
 export const OPENCODE_ZEN_CHAT_COMPLETIONS_URL = `${OPENCODE_ZEN_BASE}/chat/completions`;
 
+/**
+ * OpenCode Zen `POST /chat/completions` uses short catalog ids (`qwen3.6-plus`, `kimi-k2.5`),
+ * not OpenRouter-style `vendor/model` strings. Adapter rows store `openrouter/...` for CLI;
+ * map those here before calling Zen.
+ *
+ * @see https://opencode.ai/zen/v1/models (public list; ids are Zen-native)
+ */
+export function openCodeZenChatModelId(model: string): string {
+  const raw = model.trim();
+  if (!raw) return raw;
+  const lower = raw.toLowerCase();
+  const sansOpenrouter = lower.startsWith('openrouter/') ? lower.slice('openrouter/'.length) : lower;
+
+  const table: Record<string, string> = {
+    'qwen/qwen3.6-plus': 'qwen3.6-plus',
+    'qwen/qwen3.6-plus:free': 'qwen3.6-plus',
+    'qwen/qwen3.5-plus': 'qwen3.5-plus',
+    'moonshotai/kimi-k2.5': 'kimi-k2.5',
+    'moonshotai/kimi-k2-thinking': 'kimi-k2-thinking',
+    'moonshotai/kimi-k2': 'kimi-k2',
+    'minimax/minimax-m2.5': 'minimax-m2.5',
+    'minimax/minimax-m2.7': 'minimax-m2.5',
+    'minimax/minimax-m2.1': 'minimax-m2.1',
+    'z-ai/glm-5.1': 'glm-5.1',
+    'z-ai/glm-5': 'glm-5',
+    'z-ai/glm-4.7': 'glm-4.7',
+    'z-ai/glm-4.6': 'glm-4.6',
+  };
+
+  if (table[lower]) return table[lower];
+  if (table[sansOpenrouter]) return table[sansOpenrouter];
+
+  if (!sansOpenrouter.includes('/')) return raw;
+
+  return sansOpenrouter;
+}
+
 /** Default model for a minimal chat probe when /models does not reject bad keys. */
 const KILO_PROBE_MODEL = 'openai/gpt-4o-mini';
 

--- a/project-process/handoffs/handoff-row-100-http-adapter-20260421.md
+++ b/project-process/handoffs/handoff-row-100-http-adapter-20260421.md
@@ -1,0 +1,147 @@
+# Handoff — Row 100 HTTP Adapter
+
+> **產出時間**：2026/04/21
+> **產出者**：Claude Codex 5.3（與 Jason 對話）
+> **接手對象**：下一個 Claude session
+> **承接內容**：延續 superadmin AI settings 的 CLI/HTTP adapter 比較功能，補完未提交實作並收斂驗證與 roadmap/doc 同步。
+> **如何使用**：複製下方 fenced code block 整段，貼到新 session 的第一則 prompt
+
+---
+
+```markdown
+你是下一個接手此 repo 的 AI，請直接延續 Row 100「AI 服務設定」HTTP Adapter 比較功能。
+
+## 1) 身分與硬性規範（必遵守）
+- 回覆語言：繁體中文；程式碼註解：英文。
+- TypeScript strict，禁止 `any`（依 `CLAUDE.md` 與 `.claude/rules/general.md`）。
+- SQL 只能放 `supabase/migrations/`，檔名 `YYYYMMDDHHMMSS_description.sql`（依 `.claude/rules/backend/supabase.md`）。
+- Jason 常在平行分支同時改檔；動工前、每次 commit 前都先 `git status` 避免覆寫。
+- roadmap 進度更新檔在 `apps/superadmin/app/data/roadmap.ts`（Row 100）。
+
+## 2) 專案位置
+- Repo 絕對路徑：`/Volumes/KLEVV-4T-1/Real Estate Management Projects/Owner-Property-Management-AI-SPA`
+
+## 3) 目前 git 現況（已偵察）
+- `git status --short`：
+  - `M .claude/commands/commit-push-pr.md`
+  - `M apps/superadmin/app/api/ai-settings/adapter-runs/route.ts`
+  - `M apps/superadmin/app/superadmin/settings/api_key_and_model_setting/adapter-config-columns.tsx`
+  - `M apps/superadmin/app/superadmin/settings/api_key_and_model_setting/page.tsx`
+  - `?? apps/superadmin/app/superadmin/settings/api_key_and_model_setting/model-router-columns.tsx`
+- `git log --oneline -10` 最新是文件/指令類提交；**本次 session 尚未 commit**（請你接手後自行整理 commit）。
+
+## 4) 本次已完成的關鍵產出（未提交，請先讀）
+- 先讀順序（建立脈絡）：
+  1. `apps/superadmin/app/superadmin/settings/api_key_and_model_setting/page.tsx`
+  2. `apps/superadmin/app/api/ai-settings/adapter-runs/route.ts`
+  3. `apps/superadmin/app/superadmin/settings/api_key_and_model_setting/adapter-config-columns.tsx`
+  4. `apps/superadmin/app/data/roadmap.ts`（Row 100）
+  5. `project-process/features/ai-settings-adapter-self-report-dev-spec-20260419.md`
+
+- 已落地內容（證據）：
+  - 新增 HTTP sheet tab：`http-adapter-config`（`page.tsx` 有 `SettingsTab`/`TAB_IDS`/`SHEET_TABS` 對應）。
+  - HTTP 分頁有獨立全測按鈕與批次執行（`runAllHttpAdapters` in `page.tsx`）。
+  - HTTP 全測完成改為右上角 toast（`httpBulkToast` in `page.tsx`），不再 `window.alert`。
+  - 共用表格欄位擴充 HTTP metrics（`adapter-config-columns.tsx` 的 `showHttpMetrics`、`ttftMs/e2eLatencyMs/httpStatus/successRateRecent`）。
+  - API 支援 `mode=cli/http`（`route.ts` 有 `mode` 參數、`runHttpMode()`、統一回傳 metrics payload）。
+  - HTTP 錯誤分類（`classifyHttpError()` in `route.ts`）與最近成功率（`runHistoryByAdapter` + `successRateRecent`）。
+
+## 5) 已驗證基線（目前綠）
+先在 repo root 執行：
+
+```bash
+cd "/Volumes/KLEVV-4T-1/Real Estate Management Projects/Owner-Property-Management-AI-SPA/apps/superadmin" && npx tsc --noEmit
+```
+
+補充：本 session 實測 `npx tsc --noEmit -p apps/superadmin/tsconfig.json` 為綠。
+
+## 6) roadmap / spec 現況（已查證）
+- Row 100 在 `apps/superadmin/app/data/roadmap.ts`，目前 `percentage: 97`、`lastModifiedDate: 2026/04/19`，尚未反映這次 HTTP adapter UI/API 變更。
+- 既有 dev spec：`project-process/features/ai-settings-adapter-self-report-dev-spec-20260419.md`。
+  - 其「後續工作」提到 lint / nightly / baseline 測試，對這次 HTTP 比較功能可直接延伸。
+
+## 7) 下一步任務拆解（請直接執行）
+1. **功能完整性收斂**
+   - 檢查 `page.tsx` 的 HTTP 全測摘要計算是否用最新 state（目前有 before/after runCount 邏輯，請驗證「嘗試啟動數」計算是否受 stale ref 影響）。
+   - 驗證 HTTP tab 的比較卡指標（P50/P95、成功率、timeout、5xx）是否在「尚未跑任何測試」與「部分失敗」時有合理 fallback 顯示。
+
+2. **API 行為驗證**
+   - 實測 `route.ts`：
+     - `POST /api/ai-settings/adapter-runs` with `mode=http`
+     - `GET` 輪詢 with `mode=http`
+     - `PATCH` 在 HTTP 模式僅允許 `stop`（目前邏輯如此，請確認前端沒有呼叫 pause/resume）。
+   - 檢查 `activeRuns` in-memory 設計是否符合預期（server restart 後資料遺失可接受，但需明確記錄）。
+
+3. **文件與進度同步**
+   - 更新 Row 100 的 `percentage / lastModifiedDate / devLog`（加上本次 HTTP Adapter sheet + metrics + toast）。
+   - 新增本次 dev-log / test-log（建議路徑）：
+     - `project-process/dev-logs/dev-ai-settings-http-adapter-2026-04-21.md`
+     - `project-process/test-logs/test-ai-settings-http-adapter-2026-04-21.md`
+
+4. **測試補強（TDD 導向）**
+   - 優先補 API 單元測試（至少 cover）：
+     - `mode=http` 成功回傳 metrics
+     - `classifyHttpError` 映射（timeout/429/5xx/4xx）
+     - `successRateRecent` window 行為
+   - 補 UI 測試（若現有測試框架已覆蓋此頁）：
+     - 出現 `LLM Http Adapter調適` tab
+     - HTTP 全測按鈕存在
+     - 全測完成顯示 toast
+
+## 8) 延後 / 待辦（這次沒做完）
+- provider/model/time-window 篩選器（比較卡目前先是總覽，尚未加篩選控制）
+- `Stability Score`（spec 提及，尚未明確實作欄位）
+- 將 HTTP 量測資料持久化到 DB（目前多數為記憶體 + local snapshot）
+
+## 9) 關鍵慣例與雷區
+- Supabase import 路徑：
+  - Server（RLS）常見：`@/lib/supabase/server`
+  - Service role：admin only：`@/utils/supabase/admin`
+  - 見 `.claude/rules/backend/supabase.md`
+- RLS：所有表應啟用；管理端需有明確 service_role 理由。
+- pre-commit 可能擋：
+  - `scripts/check-staged-no-any.js`
+  - `scripts/check-critical-deps.js`
+  - `tools/testing/lint-adapter-model-ids.sh`
+  - `tools/testing/validate-test-manifest.sh`
+- 禁止降級 major（見 `.claude/rules/critical-deps.md`）：
+  - React 19 / Next 16 / TypeScript 5 / react-leaflet 5
+
+## 10) 驗收門檻（你完成本輪時需達成）
+- HTTP tab 功能可完整操作（單筆 run、全測、toast、比較卡指標正常刷新）
+- API `mode=http` 與 `mode=cli` 不互相污染，回傳 payload 欄位一致
+- `npx tsc --noEmit` 綠
+- roadmap Row 100 與 dev-log/test-log 同步更新
+- commit message 用繁中，聚焦 why（例如：`feat(superadmin): 新增 HTTP Adapter 全測與比較指標`）
+
+## 11) 動工前確認指令（先跑再改）
+```bash
+cd "/Volumes/KLEVV-4T-1/Real Estate Management Projects/Owner-Property-Management-AI-SPA"
+git status --short
+git log --oneline -5
+```
+
+動工前先跟我確認 Sprint 拆解，避免悶頭寫錯方向。
+```
+
+---
+
+## 使用方式
+1. 開新 session。
+2. 複製上方 fenced code block 內容（從 ```markdown 到結尾 ```）。
+3. 貼到新 session 第一則訊息，直接開始接手。
+
+## 相關文件
+- Roadmap：`apps/superadmin/app/data/roadmap.ts`（Row 100）
+- 本次核心修改：
+  - `apps/superadmin/app/superadmin/settings/api_key_and_model_setting/page.tsx`
+  - `apps/superadmin/app/superadmin/settings/api_key_and_model_setting/adapter-config-columns.tsx`
+  - `apps/superadmin/app/api/ai-settings/adapter-runs/route.ts`
+- 既有規格：
+  - `project-process/features/ai-settings-adapter-self-report-dev-spec-20260419.md`
+  - `project-process/features/tdd-ai-settings-adapter-self-report-20260419.md`
+- 規範：
+  - `CLAUDE.md`
+  - `.claude/rules/backend/supabase.md`
+  - `.claude/rules/critical-deps.md`
+  - `.claude/rules/backend/ai-adapter.md`

--- a/tools/testing/lint-adapter-model-ids.sh
+++ b/tools/testing/lint-adapter-model-ids.sh
@@ -105,11 +105,7 @@ const ALLOWED_PREFIXES = ['opencode/', 'openrouter/'];
 // DO NOT add new entries here without explicit approval — the point of
 // this lint is to stop new rows from landing without a prefix.
 const LEGACY_EXEMPTIONS = new Set([
-  'kilo-dola-seed-2-0-pro',
-  'kilo-qwen-3-6-plus',
-  'opencode-kimi-k2-5',
   'opencode-glm-5-1',
-  'opencode-qwen-3-6-plus',
 ]);
 
 const violations = [];


### PR DESCRIPTION
## Summary
- AI Settings 頁 CLI vs HTTP adapter 比較功能收斂：移除 CLI→HTTP 跨路徑 fallback，改為 adapter-config 每列自帶 `fallbackModels: string[]` 鏈。CLI 只鏈 CLI、HTTP 只鏈 HTTP，避免交叉污染速度與穩定度數據。
- Claude 走鏈式降級（opus→sonnet→haiku→舊版本），其他 provider 同家族依 ai_key_validation_cache 挑出 slug。
- 新增離線漂移檢查：`adapter-config-fallback-models.test.ts` 用 2026-04-21 的 validation cache snapshot 驗每個 primary/fallback 皆存在對應 provider 清單。

## 主要改動
- `lib/adapter-config.ts`：`AdapterConfigItem` 加 `fallbackModels`；12 row 填鏈。
- `api/ai-settings/adapter-runs/route.ts`：刪 `runProviderFallback` 家族 4 個 HTTP fallback helper；新增 `runCliAttempt` / `runCliChain` / `runHttpAttempt` / `runHttpChain`；`modelSource` 標 `fallback-cli:N` 或 `fallback-http:N`；`retryCount` = 使用的降級層數。
- `lib/ai-key-validation/kilo-opencode-zen.ts`：`openCodeZenChatModelId` 翻譯表補 7 組 fallback slug（kimi-k2-thinking/kimi-k2/glm-5/glm-4.7/glm-4.6/minimax-m2.1/qwen3.5-plus）。
- `lib/adapter-runs/adapter-run-meta-lines.ts`：meta-line regex 補降級鏈 log 格式。
- `adapter-config-columns.tsx`：新欄「降級鏈」read-only 顯示 `fallbackModels`。
- 連同 Row 100 先前 session 的 HTTP sheet tab、HTTP 全測按鈕、HTTP metrics 欄、`classifyHttpError`、`successRateRecent` 等 uncommitted 產出一併收斂。

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest lib/__tests__ lib/adapter-runs/__tests__ app/superadmin/settings/api_key_and_model_setting/__tests__`：116 tests passed
- [x] `npx eslint` 本次修改的檔案：無警告
- [x] `bash tools/testing/lint-adapter-model-ids.sh`：11 entries OK（既有 legacy exemption warning）
- [ ] 手動在 `http://localhost:3001/superadmin/settings/api_key_and_model_setting#adapter-config` 實測 primary 成功路徑
- [ ] 實測 primary 失敗降級到第 1 層（modelSource=fallback-cli:1 或 fallback-http:1，retryCount=1）
- [ ] 實測降級鏈耗盡（看 `CLI/HTTP 降級鏈已耗盡` log）
- [ ] 實測 PATCH `stop` 在鏈中任一層中止

🤖 Generated with [Claude Code](https://claude.com/claude-code)