### PR TITLE
feat(superadmin): 新增「各家 CLI 能力評測」分頁

### DIFF
--- a/apps/superadmin/app/api/ai-settings/cli-eval-runs/route.ts
+++ b/apps/superadmin/app/api/ai-settings/cli-eval-runs/route.ts
@@ -1,0 +1,311 @@
+// POST /api/ai-settings/cli-eval-runs
+//
+// Headless CLI evaluation runner.
+//
+// Three tools (claude / codex / copilot) launch via:
+//   ollama launch <tool> --model <ollama-cloud-model> --yes -- <tool-flags...>
+//
+// OpenCode is special: its `ollama launch opencode` headless mode hangs
+// because OPENCODE_CONFIG_CONTENT injection doesn't propagate cleanly.
+// We bypass `ollama launch` for opencode and spawn `opencode run` directly
+// with our own OPENCODE_CONFIG_CONTENT env that defines the ollama provider
+// inline (verified working in terminal, 2026-05-03).
+//
+// Verified working (terminal + API, exit=0, non-empty stdout):
+//   - claude:   ollama launch claude   --model <m> --yes -- -p "<prompt>"
+//   - codex:    ollama launch codex    --model <m> --yes -- exec --oss \
+//                  --local-provider ollama-chat -m <m> "<prompt>"
+//   - copilot:  ollama launch copilot  --model <m> --yes -- -p "<prompt>" --allow-all-tools
+//   - opencode: opencode run -m ollama/<m> "<prompt>"
+//                  (with OPENCODE_CONFIG_CONTENT defining ollama provider)
+
+import { NextRequest, NextResponse } from 'next/server';
+import { spawn } from 'node:child_process';
+import { requireSuperadmin } from '@/lib/auth/require-superadmin';
+import { createAdminClient } from '@/utils/supabase/admin';
+import { OLLAMA_CLOUD_MODELS } from '@/app/superadmin/settings/api_key_and_model_setting/cli-eval-tool-config';
+
+export const runtime = 'nodejs';
+
+const RUN_TIMEOUT_MS = 120_000;
+const MAX_OUTPUT_BYTES = 256 * 1024;
+const OLLAMA_BIN = process.env.OLLAMA_CLI_PATH || 'ollama';
+const OPENCODE_BIN = process.env.OPENCODE_CLI_PATH || 'opencode';
+const OLLAMA_OPENAI_BASE_URL = 'http://127.0.0.1:11434/v1';
+
+type CodingTool = 'claude' | 'codex' | 'opencode' | 'copilot';
+
+type ToolPlan = {
+  /** Binary to invoke. */
+  binary: string;
+  /** argv (excluding binary). */
+  args: string[];
+  /** Extra env merged on top of process.env. */
+  extraEnv?: Record<string, string>;
+  status: 'verified' | 'unverified' | 'todo';
+  notes?: string;
+};
+
+/** Build the inline opencode config that registers `ollama` as a provider. */
+function buildOpencodeInlineConfig(): string {
+  return JSON.stringify({
+    $schema: 'https://opencode.ai/config.json',
+    provider: {
+      ollama: {
+        npm: '@ai-sdk/openai-compatible',
+        options: { baseURL: OLLAMA_OPENAI_BASE_URL },
+        models: Object.fromEntries(OLLAMA_CLOUD_MODELS.map((m) => [m, {}])),
+      },
+    },
+  });
+}
+
+function planForTool(tool: CodingTool, prompt: string, model: string): ToolPlan {
+  switch (tool) {
+    case 'claude':
+      return {
+        binary: OLLAMA_BIN,
+        args: ['launch', 'claude', '--model', model, '--yes', '--', '-p', prompt],
+        status: 'verified',
+      };
+    case 'codex':
+      return {
+        binary: OLLAMA_BIN,
+        // `--oss --local-provider ollama-chat -m <model>` is required because
+        // codex 0.87 defaults to ChatGPT-account auth, which the ollama proxy
+        // refuses for non-OpenAI cloud models. The OSS path bypasses that.
+        args: ['launch', 'codex', '--model', model, '--yes', '--',
+          'exec', '--oss', '--local-provider', 'ollama-chat', '-m', model, prompt],
+        status: 'verified',
+        notes: 'codex 走 --oss + --local-provider ollama-chat 的 OSS 路徑；stdout 為空時會從 stderr 擷取 final answer。',
+      };
+    case 'copilot':
+      return {
+        binary: OLLAMA_BIN,
+        // GitHub Copilot CLI 1.0.10's `-p` is non-interactive; --allow-all-tools
+        // is required for the prompt mode to actually run without user prompts.
+        args: ['launch', 'copilot', '--model', model, '--yes', '--',
+          '-p', prompt, '--allow-all-tools'],
+        status: 'verified',
+        notes: 'copilot 結尾會附 token / 時間統計。',
+      };
+    case 'opencode':
+      // Bypass `ollama launch opencode` entirely (it hangs in headless mode).
+      // Spawn opencode directly and inject the ollama provider via env.
+      return {
+        binary: OPENCODE_BIN,
+        args: ['run', '-m', `ollama/${model}`, prompt],
+        extraEnv: { OPENCODE_CONFIG_CONTENT: buildOpencodeInlineConfig() },
+        status: 'verified',
+        notes: 'opencode 走「直接呼叫 + OPENCODE_CONFIG_CONTENT 注入 ollama provider」，未經 ollama launch wrapper。',
+      };
+  }
+}
+
+type RunResult = {
+  success: boolean;
+  status: 'done' | 'failed';
+  command: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  e2eMs: number;
+  ttftMs: number | null;
+  errorType: string;
+  message: string;
+};
+
+/** Strip ANSI escape sequences (CSI, SGR, OSC, etc.). */
+function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\[[0-9;?]*[a-zA-Z]/g, '').replace(/\][^]*/g, '');
+}
+
+/**
+ * codex exec writes all model tokens (including thinking + final answer) to
+ * STDERR when stdout is a pipe (it expects a TTY for stdout). Extract the
+ * "codex" sections (final answer) and skip "thinking" sections.
+ */
+function extractCodexAnswerFromStderr(stderr: string): string {
+  const clean = stripAnsi(stderr);
+  // After ANSI strip the stream looks like alternating lines such as
+  //   "thinking\n用\nthinking\n戶\n..."
+  //   "codex\n我是\ncodex\n OpenAI\n..."
+  // We keep only the segments that follow a "codex" header until the next
+  // tagged header, and drop "thinking", "user", "deprecated", "mcp..." lines.
+  const lines = clean.split('\n');
+  let inCodex = false;
+  const out: string[] = [];
+  const HEADER_RE = /^(thinking|codex|user|deprecated:|mcp:|mcp startup:|approval:|sandbox:|model:|provider:|workdir:|session id:)/i;
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+    if (HEADER_RE.test(line)) {
+      inCodex = /^codex\b/i.test(line);
+      continue;
+    }
+    if (inCodex) out.push(line);
+  }
+  return out.join('').replace(/\s+/g, ' ').trim();
+}
+
+function runPlan(plan: ToolPlan, codingTool: CodingTool): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    let firstByteAt: number | null = null;
+    let stdout = '';
+    let stderr = '';
+    let killed = false;
+
+    const child = spawn(plan.binary, plan.args, {
+      env: { ...process.env, ...(plan.extraEnv ?? {}) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const timer = setTimeout(() => {
+      killed = true;
+      try { child.kill('SIGKILL'); } catch { /* swallow */ }
+    }, RUN_TIMEOUT_MS);
+
+    const captureStream = (chunk: Buffer, target: 'stdout' | 'stderr') => {
+      if (firstByteAt == null) firstByteAt = Date.now();
+      const text = chunk.toString('utf8');
+      if (target === 'stdout') {
+        stdout = (stdout + text).slice(-MAX_OUTPUT_BYTES);
+      } else {
+        stderr = (stderr + text).slice(-MAX_OUTPUT_BYTES);
+      }
+    };
+
+    child.stdout.on('data', (chunk: Buffer) => captureStream(chunk, 'stdout'));
+    child.stderr.on('data', (chunk: Buffer) => captureStream(chunk, 'stderr'));
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({
+        success: false,
+        status: 'failed',
+        command: `${plan.binary} ${plan.args.join(' ')}`,
+        stdout,
+        stderr: stderr + `\n[spawn-error] ${err.message}`,
+        exitCode: null,
+        e2eMs: Date.now() - startedAt,
+        ttftMs: firstByteAt == null ? null : firstByteAt - startedAt,
+        errorType: 'spawn_error',
+        message: `無法啟動 ${plan.binary}：${err.message}。請確認該 binary 已安裝並在 PATH 中。`,
+      });
+    });
+
+    child.on('close', (exitCode) => {
+      clearTimeout(timer);
+      const e2eMs = Date.now() - startedAt;
+      const ttftMs = firstByteAt == null ? null : firstByteAt - startedAt;
+      const cmdLabel = `${plan.binary} ${plan.args.join(' ')}`;
+      if (killed) {
+        resolve({
+          success: false,
+          status: 'failed',
+          command: cmdLabel,
+          stdout,
+          stderr,
+          exitCode,
+          e2eMs,
+          ttftMs,
+          errorType: 'timeout',
+          message: `CLI 執行超過 ${Math.round(RUN_TIMEOUT_MS / 1000)} 秒已強制終止。`,
+        });
+        return;
+      }
+      // codex writes model output to stderr when stdout is a pipe. Promote
+      // the extracted codex segment back into stdout for downstream consumers.
+      let effectiveStdout = stdout;
+      if (codingTool === 'codex' && stdout.trim().length === 0 && stderr.length > 0) {
+        const extracted = extractCodexAnswerFromStderr(stderr);
+        if (extracted) effectiveStdout = extracted;
+      }
+      const ok = (exitCode == null || exitCode === 0) && effectiveStdout.trim().length > 0;
+      let errorType = '';
+      if (!ok) {
+        if (exitCode != null && exitCode !== 0) errorType = `exit-${exitCode}`;
+        else errorType = 'empty_output';
+      }
+      resolve({
+        success: ok,
+        status: ok ? 'done' : 'failed',
+        command: cmdLabel,
+        stdout: effectiveStdout,
+        stderr,
+        exitCode,
+        e2eMs,
+        ttftMs,
+        errorType,
+        message: ok
+          ? 'CLI 已完成回應。'
+          : (exitCode != null && exitCode !== 0
+            ? `CLI 以非零退出碼結束（exit ${exitCode}）。詳細見 stderr。`
+            : 'CLI 結束但無模型輸出。'),
+      });
+    });
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = createAdminClient();
+  const auth = await requireSuperadmin({
+    request,
+    adminClient: supabase,
+    routeLabel: 'api/ai-settings/cli-eval-runs',
+  });
+  if (!auth.ok) {
+    return NextResponse.json({ success: false, message: auth.message }, { status: auth.status });
+  }
+
+  let body: { codingTool?: string; ollamaModel?: string; prompt?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, message: '請求 body 必須是 JSON。' }, { status: 400 });
+  }
+
+  const codingTool = (body.codingTool ?? '').trim() as CodingTool;
+  const ollamaModel = (body.ollamaModel ?? '').trim();
+  const prompt = (body.prompt ?? '').trim();
+
+  if (!['claude', 'codex', 'opencode', 'copilot'].includes(codingTool)) {
+    return NextResponse.json({ success: false, message: `不支援的 codingTool: ${codingTool}` }, { status: 400 });
+  }
+  if (!ollamaModel) {
+    return NextResponse.json({ success: false, message: '缺少 ollamaModel。' }, { status: 400 });
+  }
+  if (!prompt) {
+    return NextResponse.json({ success: false, message: '缺少 prompt。' }, { status: 400 });
+  }
+
+  const plan = planForTool(codingTool, prompt, ollamaModel);
+
+  if (plan.status === 'todo') {
+    return NextResponse.json({
+      success: false,
+      status: 'failed',
+      command: '(skipped)',
+      stdout: '',
+      stderr: '',
+      exitCode: null,
+      e2eMs: 0,
+      ttftMs: null,
+      errorType: 'todo',
+      message: plan.notes ?? '此 CLI 尚未支援 headless 模式。',
+      codingTool,
+      ollamaModel,
+    });
+  }
+
+  const result = await runPlan(plan, codingTool);
+
+  return NextResponse.json({
+    ...result,
+    codingTool,
+    ollamaModel,
+    notes: plan.notes,
+    toolStatus: plan.status,
+  });
+}

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/CliCapabilityEvaluationPanel.tsx
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/CliCapabilityEvaluationPanel.tsx
@@ -337,7 +337,7 @@ function CliCapabilityDetailSheet({
         <div className="border-b border-border-default px-4 py-3">
           <p className="text-[11px] font-semibold text-text-muted">啟動命令（headless）</p>
           <pre className="mt-1 max-h-[120px] overflow-auto rounded bg-bg-tertiary p-2 font-mono text-[11px] leading-4 text-text-primary">
-            {detail.command || `${tool?.cliBinary ?? detail.codingTool} ...`}
+            {detail.command || tool?.commandPreview || `${detail.codingTool} ...`}
           </pre>
         </div>
 

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/CliCapabilityEvaluationPanel.tsx
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/CliCapabilityEvaluationPanel.tsx
@@ -1,0 +1,364 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Dice5, Play, X } from 'lucide-react';
+import EnhancedTable from '@/components/ui/EnhancedTable';
+import { readLocalStorage, writeLocalStorage } from '@/lib/utils/storage-state';
+import {
+  CLI_CAPABILITY_INITIAL_WIDTHS,
+  CLI_CAPABILITY_MIN_WIDTH_PX,
+  CLI_CAPABILITY_TABLE_ID,
+  createCliCapabilityColumns,
+  getCliCapabilityCategoryValue,
+  getCliCapabilitySearchValue,
+} from './cli-capability-evaluation-columns';
+import {
+  createCustomCliCapabilityRow,
+  duplicateCliCapabilityRow,
+  fromStoredRows,
+  normalizeCliCapabilityRows,
+  rowToStored,
+  type CliCapabilityRow,
+  type StoredCliCapabilityRow,
+} from './cli-capability-row-state';
+import {
+  findToolConfig,
+  OLLAMA_CLOUD_MODELS,
+  pickRandomOllamaModel,
+} from './cli-eval-tool-config';
+
+const LS_CLI_CAPABILITY_ROWS = 'ai-settings:cli-capability:rows-v2';
+
+type CliEvalRunResponse = {
+  success: boolean;
+  status?: 'done' | 'failed';
+  command?: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+  e2eMs?: number;
+  ttftMs?: number | null;
+  errorType?: string;
+  message?: string;
+  envInjected?: Record<string, string>;
+  codingTool?: string;
+  ollamaModel?: string;
+};
+
+async function runCliEval(row: CliCapabilityRow): Promise<CliEvalRunResponse> {
+  const response = await fetch('/api/ai-settings/cli-eval-runs', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      codingTool: row.codingTool,
+      ollamaModel: row.ollamaModel,
+      prompt: row.prompt,
+    }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    return { success: false, message: `啟動失敗（HTTP ${response.status}）${text ? `: ${text}` : ''}`, status: 'failed' };
+  }
+  return response.json() as Promise<CliEvalRunResponse>;
+}
+
+/** Pull a self-introduction snippet (e.g. "MiniMax-M2.7") out of stdout for the Eff column. */
+function detectSelfReportedModel(stdout: string): string {
+  const trimmed = stdout.trim();
+  if (!trimmed) return '';
+  const candidates = [
+    /minimax[- ]?m?\d+(?:[.\-]\d+)?/i,
+    /kimi[- ]?k?\d+(?:[.\-]\d+)?/i,
+    /gpt[- ]?\d+(?:[.\-]\d+)?(?:o|o-mini|turbo|codex)?/i,
+    /claude[- ]?\d+(?:[.\-]\d+)?(?:[- ]?(opus|sonnet|haiku))?/i,
+    /qwen[- ]?\d+(?:[.\-]\d+)?(?:[- ]?(coder|plus|max))?/i,
+    /deepseek[- ]?v?\d+(?:[.\-]\d+)?/i,
+    /gpt[- ]?oss/i,
+    /gemini[- ]?\d+(?:[.\-]\d+)?/i,
+    /llama[- ]?\d+/i,
+    /grok[- ]?\d+/i,
+  ];
+  for (const re of candidates) {
+    const m = trimmed.match(re);
+    if (m) return m[0];
+  }
+  return '';
+}
+
+export function CliCapabilityEvaluationPanel() {
+  const [rows, setRows] = useState<CliCapabilityRow[]>(() => {
+    const stored = readLocalStorage<StoredCliCapabilityRow[]>(LS_CLI_CAPABILITY_ROWS, []);
+    return fromStoredRows(stored);
+  });
+  const [detailRow, setDetailRow] = useState<CliCapabilityRow | null>(null);
+  const cancelledIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    writeLocalStorage(LS_CLI_CAPABILITY_ROWS, rows.map(rowToStored));
+  }, [rows]);
+
+  const patchRow = useCallback((rowId: string, patch: Partial<CliCapabilityRow>) => {
+    setRows((prev) => prev.map((row) => row.id === rowId ? { ...row, ...patch } : row));
+  }, []);
+
+  const addRow = useCallback(() => {
+    setRows((prev) => normalizeCliCapabilityRows([
+      ...prev,
+      createCustomCliCapabilityRow(prev.length + 1),
+    ]));
+  }, []);
+
+  const deleteRow = useCallback((rowId: string) => {
+    cancelledIdsRef.current.add(rowId);
+    setRows((prev) => {
+      const next = prev.filter((row) => row.id !== rowId);
+      if (next.length > 0) return normalizeCliCapabilityRows(next);
+      return [createCustomCliCapabilityRow(1)];
+    });
+  }, []);
+
+  const duplicateRow = useCallback((row: CliCapabilityRow) => {
+    setRows((prev) => normalizeCliCapabilityRows([
+      ...prev,
+      duplicateCliCapabilityRow(row, prev.length + 1),
+    ]));
+  }, []);
+
+  const openDetailRow = useCallback((row: CliCapabilityRow) => {
+    setDetailRow(row);
+  }, []);
+
+  const randomModel = useCallback((rowId: string) => {
+    setRows((prev) => prev.map((row) => row.id === rowId
+      ? { ...row, ollamaModel: pickRandomOllamaModel(row.ollamaModel) }
+      : row));
+  }, []);
+
+  const randomAllModels = useCallback(() => {
+    setRows((prev) => prev.map((row) => ({
+      ...row,
+      ollamaModel: pickRandomOllamaModel(row.ollamaModel),
+    })));
+  }, []);
+
+  const runRow = useCallback(async (row: CliCapabilityRow) => {
+    if (row.runStatus === 'running') return;
+    const tool = findToolConfig(row.codingTool);
+    if (tool?.status === 'todo') {
+      patchRow(row.id, {
+        runStatus: 'failed',
+        errorType: 'todo',
+        message: tool.notes ?? '此 CLI 尚未支援 headless 模式。',
+        runStartedAtMs: null,
+        lastRunAt: new Date().toISOString(),
+      });
+      return;
+    }
+    cancelledIdsRef.current.delete(row.id);
+
+    const startedAtMs = Date.now();
+    patchRow(row.id, {
+      runStatus: 'running',
+      runStartedAtMs: startedAtMs,
+      message: `啟動 ${tool?.label ?? row.codingTool}（model: ${row.ollamaModel}）…`,
+      resultText: '',
+      rawLogs: [],
+      command: '',
+      effectiveModel: '',
+      modelSource: '',
+      ttftMs: null,
+      e2eMs: null,
+      tokensPerSec: null,
+      exitStatus: null,
+      errorType: '',
+    });
+
+    const response = await runCliEval(row);
+    if (cancelledIdsRef.current.has(row.id)) return;
+
+    const stdout = response.stdout ?? '';
+    const stderr = response.stderr ?? '';
+    const rawLogs = [
+      response.command ? `$ ${response.command}` : '',
+      stdout && `--- stdout ---\n${stdout}`,
+      stderr && `--- stderr ---\n${stderr}`,
+    ].filter(Boolean).join('\n\n').split('\n');
+
+    const isDone = response.success && response.status === 'done';
+    patchRow(row.id, {
+      runStatus: isDone ? 'done' : 'failed',
+      runStartedAtMs: null,
+      command: response.command ?? '',
+      resultText: stdout,
+      rawLogs,
+      effectiveModel: detectSelfReportedModel(stdout),
+      modelSource: 'stdout-self-report',
+      ttftMs: response.ttftMs ?? null,
+      e2eMs: response.e2eMs ?? Date.now() - startedAtMs,
+      exitStatus: response.exitCode ?? null,
+      errorType: response.errorType ?? '',
+      message: response.message ?? (isDone ? 'CLI 完成。' : 'CLI 失敗。'),
+      lastRunAt: new Date().toISOString(),
+    });
+  }, [patchRow]);
+
+  const columns = useMemo(
+    () => createCliCapabilityColumns({
+      onPatchRow: patchRow,
+      onRunRow: (row) => void runRow(row),
+      onDeleteRow: deleteRow,
+      onDuplicateRow: duplicateRow,
+      onOpenDetail: openDetailRow,
+      onRandomModel: randomModel,
+    }),
+    [deleteRow, duplicateRow, openDetailRow, patchRow, randomModel, runRow],
+  );
+
+  const runAll = useCallback(async () => {
+    const runnable = rows.filter((row) => row.shouldTest && row.runStatus !== 'running');
+    if (runnable.length === 0) return;
+    // CLI calls hit local subprocesses + ollama daemon — limit concurrency so
+    // we don't oversubscribe both. 2 is a conservative starting point.
+    const concurrency = 2;
+    for (let i = 0; i < runnable.length; i += concurrency) {
+      const batch = runnable.slice(i, i + concurrency);
+      await Promise.allSettled(batch.map((row) => runRow(row)));
+    }
+  }, [rows, runRow]);
+
+  const detail = detailRow ? rows.find((row) => row.id === detailRow.id) ?? detailRow : null;
+
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2">
+      <div className="shrink-0 rounded-base border border-dashed border-border-default bg-bg-secondary px-3 py-2 text-[11px] text-text-secondary">
+        <p>
+          <span className="font-semibold text-text-primary">執行模式：</span>
+          每列實際 spawn{' '}
+          <code className="font-mono">ollama launch &lt;tool&gt; --model &lt;m&gt; --yes -- &lt;headless flags&gt;</code>
+          （由 ollama 0.21+ 自家 wrapper 注入 backend env / proxy）。
+          ✓claude / ✓codex（OSS 路徑）/ ✓copilot 已驗證可拿到 stdout；
+          opencode 在 headless 下尚未通，需先在 terminal 跑{' '}
+          <code className="font-mono">ollama launch opencode --config</code> 完成 ollama provider 設定。
+        </p>
+      </div>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <EnhancedTable<CliCapabilityRow>
+          tableId={CLI_CAPABILITY_TABLE_ID}
+          columns={columns}
+          data={rows}
+          initialWidths={[...CLI_CAPABILITY_INITIAL_WIDTHS]}
+          minWidth={CLI_CAPABILITY_MIN_WIDTH_PX}
+          stretchToContainer={false}
+          fillAvailableHeight
+          persistentHorizontalScrollbar
+          onAddRow={addRow}
+          getSearchValue={getCliCapabilitySearchValue}
+          getCategoryValue={getCliCapabilityCategoryValue}
+          extraToolbar={
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => randomAllModels()}
+                className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border-default bg-bg-secondary px-3 text-xs font-semibold text-text-secondary transition hover:text-text-primary"
+                title="🎲 一鍵為所有列重抽 ollama cloud 模型"
+              >
+                <Dice5 size={14} aria-hidden />
+                全表隨機抽模型
+              </button>
+              <button
+                type="button"
+                onClick={() => void runAll()}
+                className="inline-flex h-8 items-center gap-1.5 rounded-md bg-emerald-600 px-3 text-xs font-semibold text-white transition hover:bg-emerald-700"
+                title="依勾選列依序啟動 CLI 評測"
+              >
+                <Play size={14} aria-hidden />
+                全測（CLI）
+              </button>
+            </div>
+          }
+        />
+      </div>
+
+      {detail && (
+        <CliCapabilityDetailSheet
+          detail={detail}
+          onClose={() => setDetailRow(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function CliCapabilityDetailSheet({
+  detail,
+  onClose,
+}: {
+  detail: CliCapabilityRow;
+  onClose: () => void;
+}) {
+  const tool = findToolConfig(detail.codingTool);
+  const rawText = detail.rawLogs.length > 0 ? detail.rawLogs.join('\n') : '（尚無 log）';
+  return (
+    <div className="fixed inset-0 z-[80] flex justify-end bg-black/40" role="dialog" aria-modal>
+      <div className="flex h-full w-full max-w-[680px] flex-col bg-bg-primary shadow-2xl">
+        <header className="flex items-start justify-between border-b border-border-default px-4 py-3">
+          <div className="min-w-0">
+            <p className="text-xs text-text-muted">CLI 評測詳情</p>
+            <h3 className="truncate text-sm font-semibold text-text-primary">
+              {tool?.label ?? detail.codingTool} · <span className="font-mono">{detail.ollamaModel}</span>
+            </h3>
+            <p className="mt-1 text-[11px] text-text-secondary">
+              指定 ollama model：<span className="font-mono">{detail.ollamaModel || '—'}</span>
+              {' '}· 自介：<span className="font-mono">{detail.effectiveModel || '—'}</span>
+            </p>
+            {tool?.notes && (
+              <p className="mt-1 text-[11px] text-amber-700">{tool.notes}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 w-8 items-center justify-center rounded border border-border-subtle text-text-secondary hover:bg-bg-secondary"
+            aria-label="關閉"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div className="grid grid-cols-2 gap-3 border-b border-border-default px-4 py-3 text-[11px] text-text-secondary">
+          <p>狀態：<span className="font-mono text-text-primary">{detail.runStatus}</span></p>
+          <p>TTFT：<span className="font-mono">{detail.ttftMs == null ? '—' : `${Math.round(detail.ttftMs)} ms`}</span></p>
+          <p>E2E：<span className="font-mono">{detail.e2eMs == null ? '—' : `${Math.round(detail.e2eMs)} ms`}</span></p>
+          <p>tok/s：<span className="font-mono">{detail.tokensPerSec == null ? '—' : detail.tokensPerSec.toFixed(1)}</span></p>
+          <p>Exit code：<span className="font-mono">{detail.exitStatus ?? '—'}</span></p>
+          <p>錯誤：<span className="font-mono">{detail.errorType || '—'}</span></p>
+        </div>
+
+        <div className="border-b border-border-default px-4 py-3">
+          <p className="text-[11px] font-semibold text-text-muted">啟動命令（headless）</p>
+          <pre className="mt-1 max-h-[120px] overflow-auto rounded bg-bg-tertiary p-2 font-mono text-[11px] leading-4 text-text-primary">
+            {detail.command || `${tool?.cliBinary ?? detail.codingTool} ...`}
+          </pre>
+        </div>
+
+        <div className="border-b border-border-default px-4 py-3">
+          <p className="text-[11px] font-semibold text-text-muted">模型輸出（stdout）</p>
+          <pre className="mt-1 max-h-[200px] overflow-auto rounded bg-bg-tertiary p-2 font-mono text-[11px] leading-4 text-text-primary whitespace-pre-wrap">
+            {detail.resultText || detail.message || '尚未取得結果。'}
+          </pre>
+        </div>
+
+        <div className="flex-1 overflow-hidden px-4 py-3">
+          <p className="text-[11px] font-semibold text-text-muted">完整 Raw Log（含 stderr）</p>
+          <pre className="mt-1 h-[calc(100%-1.5rem)] overflow-auto rounded bg-bg-tertiary p-2 font-mono text-[11px] leading-4 text-text-primary whitespace-pre-wrap">
+            {rawText}
+          </pre>
+          <p className="mt-2 text-[10px] text-text-muted">
+            可用 ollama cloud 模型清單（{OLLAMA_CLOUD_MODELS.length}）：
+            <span className="font-mono">{OLLAMA_CLOUD_MODELS.join(', ')}</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/cli-capability-evaluation-columns.tsx
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/cli-capability-evaluation-columns.tsx
@@ -1,0 +1,401 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { createColumnHelper, type ColumnDef } from '@tanstack/react-table';
+import { Copy, Dice5, Eye, Loader2, Play, Trash2 } from 'lucide-react';
+import {
+  findToolConfig,
+  OLLAMA_CLOUD_MODELS,
+  TOOL_CONFIGS,
+  type CodingTool,
+} from './cli-eval-tool-config';
+import type { CliCapabilityRow, CliCapabilityRunStatus } from './cli-capability-row-state';
+
+export const CLI_CAPABILITY_TABLE_ID = 'ai-settings-cli-capability-evaluation-v2';
+export const CLI_CAPABILITY_INITIAL_WIDTHS = [
+  3, 4, 5, 5, 5, 7, 7, 14, 5, 9, 13, 5, 4, 4, 4, 4, 7,
+] as const;
+export const CLI_CAPABILITY_MIN_WIDTH_PX = 4400;
+
+type CreateColumnsDeps = {
+  onPatchRow: (rowId: string, patch: Partial<CliCapabilityRow>) => void;
+  onRunRow: (row: CliCapabilityRow) => void;
+  onDeleteRow: (rowId: string) => void;
+  onDuplicateRow: (row: CliCapabilityRow) => void;
+  onOpenDetail: (row: CliCapabilityRow) => void;
+  onRandomModel: (rowId: string) => void;
+};
+
+const col = createColumnHelper<CliCapabilityRow>();
+
+function statusLabel(status: CliCapabilityRunStatus): string {
+  if (status === 'done') return '完成';
+  if (status === 'failed') return '失敗';
+  if (status === 'running') return 'CLI 執行中';
+  return '尚未測試';
+}
+
+function executionPlaneLabel(_codingTool: CodingTool): string {
+  return '本機 CLI → ollama daemon';
+}
+
+function stopTablePointerEvent(event: React.SyntheticEvent) {
+  event.stopPropagation();
+}
+
+function ElapsedLabel({
+  runStatus,
+  runStartedAtMs,
+}: {
+  runStatus: CliCapabilityRunStatus;
+  runStartedAtMs: number | null;
+}) {
+  const [elapsedSec, setElapsedSec] = useState(0);
+
+  useEffect(() => {
+    if (runStatus !== 'running' || runStartedAtMs == null) return;
+    const tick = () => setElapsedSec((Date.now() - runStartedAtMs) / 1000);
+    tick();
+    const id = setInterval(tick, 200);
+    return () => clearInterval(id);
+  }, [runStatus, runStartedAtMs]);
+
+  if (runStatus !== 'running' || runStartedAtMs == null) return null;
+  return (
+    <span className="ml-1 inline-flex items-center text-[11px] text-emerald-800 tabular-nums font-mono font-semibold" aria-live="polite">
+      {elapsedSec.toFixed(1)}s
+    </span>
+  );
+}
+
+export function getCliCapabilitySearchValue(row: CliCapabilityRow): string {
+  const tool = findToolConfig(row.codingTool);
+  return [
+    tool?.label ?? row.codingTool,
+    row.ollamaModel,
+    row.prompt,
+    row.resultText,
+    row.message,
+  ].filter(Boolean).join('\n');
+}
+
+export function getCliCapabilityCategoryValue(row: CliCapabilityRow): string {
+  const tool = findToolConfig(row.codingTool);
+  return tool?.label ?? row.codingTool;
+}
+
+export function createCliCapabilityColumns(deps: CreateColumnsDeps): ColumnDef<CliCapabilityRow, unknown>[] {
+  const { onPatchRow, onRunRow, onDeleteRow, onDuplicateRow, onOpenDetail, onRandomModel } = deps;
+  return [
+    col.display({
+      id: 'no',
+      header: 'No',
+      meta: { headerEn: 'No.', headerZh: '編號' },
+      cell: ({ row }) => <span className="font-mono text-xs tabular-nums text-text-secondary">{row.original.no}</span>,
+    }),
+    col.display({
+      id: 'should-test',
+      header: 'Test?',
+      meta: { headerEn: 'Whether to test', headerZh: '是否測試' },
+      cell: ({ row }) => (
+        <input
+          type="checkbox"
+          checked={row.original.shouldTest}
+          onChange={(event) => onPatchRow(row.original.id, { shouldTest: event.target.checked })}
+          onMouseDown={stopTablePointerEvent}
+          onClick={stopTablePointerEvent}
+          className="h-4 w-4 cursor-pointer rounded border-border-default text-emerald-600 focus:ring-emerald-500"
+        />
+      ),
+    }),
+    col.display({
+      id: 'row-actions',
+      header: 'Actions',
+      meta: { headerEn: 'Actions', headerZh: '操作' },
+      cell: ({ row }) => (
+        <button
+          type="button"
+          title="刪除此列"
+          onClick={(event) => { event.stopPropagation(); onDeleteRow(row.original.id); }}
+          className="inline-flex h-7 w-7 items-center justify-center rounded border border-border-subtle bg-bg-primary text-rose-500 hover:bg-bg-tertiary"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      ),
+    }),
+    col.display({
+      id: 'invocation-path',
+      header: 'Invoke',
+      meta: { headerEn: 'Invocation path', headerZh: '觸發路徑' },
+      cell: ({ row }) => {
+        const tool = findToolConfig(row.original.codingTool);
+        const isTodo = tool?.status === 'todo';
+        const isUnverified = tool?.status === 'unverified';
+        const className = isTodo
+          ? 'bg-rose-50 text-rose-800 border-rose-200'
+          : isUnverified
+            ? 'bg-amber-50 text-amber-800 border-amber-200'
+            : 'bg-emerald-50 text-emerald-800 border-emerald-200';
+        const label = isTodo
+          ? 'ollama launch（TODO）'
+          : isUnverified
+            ? 'ollama launch ⚠'
+            : 'ollama launch ✓';
+        return (
+          <span
+            className={`inline-flex rounded-full px-2 py-0.5 text-[10px] border ${className}`}
+            title={tool?.notes ?? tool?.commandPreview}
+          >
+            {label}
+          </span>
+        );
+      },
+    }),
+    col.display({
+      id: 'execution-plane',
+      header: 'Compute',
+      meta: { headerEn: 'Execution plane', headerZh: '運算面' },
+      cell: ({ row }) => (
+        <span className="inline-flex rounded-full bg-bg-tertiary px-2 py-0.5 text-[10px] text-text-primary">
+          {executionPlaneLabel(row.original.codingTool)}
+        </span>
+      ),
+    }),
+    col.display({
+      id: 'coding-tool',
+      header: 'Coding Tool',
+      meta: { headerEn: 'Coding tool wrapper', headerZh: 'Coding Tool（CLI 殼）' },
+      cell: ({ row }) => {
+        const r = row.original;
+        return (
+          <select
+            value={r.codingTool}
+            onMouseDown={stopTablePointerEvent}
+            onPointerDown={stopTablePointerEvent}
+            onClick={stopTablePointerEvent}
+            onChange={(event) => onPatchRow(r.id, { codingTool: event.target.value as CodingTool })}
+            className="h-8 w-full min-w-[160px] rounded-md border border-border-default bg-bg-secondary px-2 text-xs text-text-primary outline-none focus:border-emerald-500"
+          >
+            {TOOL_CONFIGS.map((tool) => (
+              <option key={tool.id} value={tool.id}>
+                {tool.label}
+                {tool.status === 'todo' ? '（TODO）' : tool.status === 'unverified' ? '（⚠ 需先設定）' : ''}
+              </option>
+            ))}
+          </select>
+        );
+      },
+    }),
+    col.display({
+      id: 'ollama-model',
+      header: 'Ollama Model',
+      meta: { headerEn: 'Ollama cloud model', headerZh: 'Ollama Cloud 模型' },
+      cell: ({ row }) => {
+        const r = row.original;
+        return (
+          <div className="flex items-center gap-1">
+            <select
+              value={r.ollamaModel}
+              onMouseDown={stopTablePointerEvent}
+              onPointerDown={stopTablePointerEvent}
+              onClick={stopTablePointerEvent}
+              onChange={(event) => onPatchRow(r.id, { ollamaModel: event.target.value })}
+              className="h-8 flex-1 min-w-[200px] rounded-md border border-border-default bg-bg-secondary px-2 text-xs text-text-primary outline-none focus:border-emerald-500"
+            >
+              {OLLAMA_CLOUD_MODELS.map((model) => (
+                <option key={model} value={model}>
+                  {model}
+                </option>
+              ))}
+              {!OLLAMA_CLOUD_MODELS.includes(r.ollamaModel) && r.ollamaModel && (
+                <option value={r.ollamaModel}>{r.ollamaModel}（自訂）</option>
+              )}
+            </select>
+            <button
+              type="button"
+              title="🎲 隨機抽一個 ollama cloud 模型"
+              onClick={(event) => { event.stopPropagation(); event.preventDefault(); onRandomModel(r.id); }}
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-border-subtle bg-bg-primary text-text-secondary hover:bg-bg-tertiary hover:text-emerald-600"
+            >
+              <Dice5 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        );
+      },
+    }),
+    col.display({
+      id: 'test-prompt',
+      header: 'Test prompt',
+      meta: { headerEn: 'Test prompt', headerZh: '測試 Prompt' },
+      cell: ({ row }) => (
+        <textarea
+          value={row.original.prompt}
+          onMouseDown={stopTablePointerEvent}
+          onPointerDown={stopTablePointerEvent}
+          onClick={stopTablePointerEvent}
+          onChange={(event) => onPatchRow(row.original.id, { prompt: event.target.value })}
+          className="h-24 w-full min-w-[360px] resize-none rounded-md border border-border-default bg-bg-secondary p-2 font-mono text-[11px] leading-4 text-text-primary outline-none focus:border-emerald-500"
+        />
+      ),
+    }),
+    col.display({
+      id: 'run-controls',
+      header: 'Run',
+      meta: { headerEn: 'Run controls', headerZh: '執行控制' },
+      cell: ({ row }) => {
+        const r = row.original;
+        const running = r.runStatus === 'running';
+        const tool = findToolConfig(r.codingTool);
+        const disabled = running || tool?.status === 'todo';
+        return (
+          <div className="flex flex-wrap items-center gap-1">
+            <button
+              type="button"
+              title={tool?.status === 'todo' ? '此 CLI 尚未支援 headless 模式' : '開始 CLI 評測'}
+              disabled={disabled}
+              onClick={(event) => { event.stopPropagation(); event.preventDefault(); onRunRow(r); }}
+              className="inline-flex h-7 w-7 items-center justify-center rounded border border-border-subtle bg-bg-primary text-emerald-600 hover:bg-bg-tertiary disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {running ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
+            </button>
+            <button
+              type="button"
+              title="複製成新列"
+              onClick={(event) => { event.stopPropagation(); event.preventDefault(); onDuplicateRow(r); }}
+              className="inline-flex h-7 w-7 items-center justify-center rounded border border-border-subtle bg-bg-primary text-text-secondary hover:bg-bg-tertiary"
+            >
+              <Copy className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              title="檢視詳情 / Raw 輸出"
+              onClick={(event) => { event.stopPropagation(); event.preventDefault(); onOpenDetail(r); }}
+              className="inline-flex h-7 w-7 items-center justify-center rounded border border-border-subtle bg-bg-primary text-text-secondary hover:bg-bg-tertiary"
+            >
+              <Eye className="h-3.5 w-3.5" />
+            </button>
+            <ElapsedLabel runStatus={r.runStatus} runStartedAtMs={r.runStartedAtMs} />
+          </div>
+        );
+      },
+    }),
+    col.display({
+      id: 'requested-effective',
+      header: 'Req / Eff',
+      meta: { headerEn: 'Requested / Effective model', headerZh: '指定型號／實際自介' },
+      cell: ({ row }) => {
+        const r = row.original;
+        return (
+          <div className="space-y-0.5 text-[11px] text-text-secondary">
+            <p>
+              指定：<span className="font-mono text-text-primary">{r.ollamaModel || '—'}</span>
+            </p>
+            <p>
+              自介：
+              <span className="font-mono text-amber-600">{r.effectiveModel || '—'}</span>
+            </p>
+            {r.modelSource && (
+              <p className="text-[10px] text-text-muted">來源：{r.modelSource}</p>
+            )}
+          </div>
+        );
+      },
+    }),
+    col.display({
+      id: 'raw-output',
+      header: 'Raw',
+      meta: { headerEn: 'Real-time raw output', headerZh: 'Raw 輸出（即時）' },
+      cell: ({ row }) => {
+        const r = row.original;
+        const lastLines = r.rawLogs.slice(-3).join('\n');
+        const preview = lastLines || r.resultText || r.message || '';
+        return (
+          <button
+            type="button"
+            title="點擊查看完整 Raw 輸出"
+            onClick={(event) => { event.stopPropagation(); event.preventDefault(); onOpenDetail(r); }}
+            className="block w-full max-w-[420px] truncate text-left font-mono text-[11px] leading-4 text-text-secondary hover:text-text-primary"
+          >
+            <span className="block truncate">{preview || '尚未執行'}</span>
+          </button>
+        );
+      },
+    }),
+    col.display({
+      id: 'llm-evaluation',
+      header: 'Result',
+      meta: { headerEn: 'Result', headerZh: '測試結果' },
+      cell: ({ row }) => {
+        const r = row.original;
+        const className = r.runStatus === 'done'
+          ? 'border-emerald-300 bg-emerald-100 text-emerald-800'
+          : r.runStatus === 'failed'
+            ? 'border-rose-300 bg-rose-100 text-rose-800'
+            : r.runStatus === 'running'
+              ? 'border-sky-300 bg-sky-50 text-sky-900'
+              : 'border-slate-300 bg-slate-100 text-slate-700';
+        return <span className={`inline-flex rounded-md border px-2 py-1 text-xs font-semibold ${className}`}>{statusLabel(r.runStatus)}</span>;
+      },
+    }),
+    col.display({
+      id: 'ttft',
+      header: 'TTFT (ms)',
+      meta: { headerEn: 'TTFT (ms)', headerZh: 'TTFT (ms) 首 token 延遲' },
+      cell: ({ row }) => (
+        <span className="font-mono text-xs tabular-nums text-text-muted">
+          {row.original.ttftMs == null ? '—' : Math.round(row.original.ttftMs)}
+        </span>
+      ),
+    }),
+    col.display({
+      id: 'e2e',
+      header: 'E2E (ms)',
+      meta: { headerEn: 'E2E (ms)', headerZh: 'E2E (ms) 完成時間' },
+      cell: ({ row }) => (
+        <span className="font-mono text-xs tabular-nums text-text-muted">
+          {row.original.e2eMs == null ? '—' : Math.round(row.original.e2eMs)}
+        </span>
+      ),
+    }),
+    col.display({
+      id: 'throughput',
+      header: 'tok/s',
+      meta: { headerEn: 'Throughput (tokens/s)', headerZh: '吞吐（tokens/s）' },
+      cell: ({ row }) => (
+        <span className="font-mono text-xs tabular-nums text-text-muted">
+          {row.original.tokensPerSec == null ? '—' : row.original.tokensPerSec.toFixed(1)}
+        </span>
+      ),
+    }),
+    col.display({
+      id: 'exit-status',
+      header: 'Exit',
+      meta: { headerEn: 'CLI exit code', headerZh: 'CLI 退出碼 / 錯誤類別' },
+      cell: ({ row }) => {
+        const r = row.original;
+        if (r.errorType) {
+          return <span className="text-[11px] text-rose-600">{r.errorType}</span>;
+        }
+        return (
+          <span className="font-mono text-xs tabular-nums text-text-muted">
+            {r.exitStatus ?? '—'}
+          </span>
+        );
+      },
+    }),
+    col.display({
+      id: 'test-history',
+      header: 'History',
+      meta: { headerEn: 'Test history', headerZh: '上次執行' },
+      cell: ({ row }) => (
+        <button
+          type="button"
+          onClick={(event) => { event.stopPropagation(); event.preventDefault(); onOpenDetail(row.original); }}
+          className="text-left text-[11px] text-text-secondary hover:text-text-primary"
+        >
+          {row.original.lastRunAt ? new Date(row.original.lastRunAt).toLocaleString() : '尚無紀錄'}
+        </button>
+      ),
+    }),
+  ];
+}

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/cli-capability-row-state.ts
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/cli-capability-row-state.ts
@@ -1,0 +1,170 @@
+import { DEFAULT_ADAPTER_TEST_PROMPT } from '@/lib/adapter-config';
+import {
+  OLLAMA_CLOUD_MODELS,
+  TOOL_CONFIGS,
+  type CodingTool,
+} from './cli-eval-tool-config';
+
+export type CliCapabilityRunStatus = 'idle' | 'running' | 'done' | 'failed';
+
+export type CliCapabilityRow = {
+  id: string;
+  no: number;
+  isBaseline: boolean;
+  shouldTest: boolean;
+  /** Which coding-tool wrapper to invoke (claude / codex / opencode / copilot). */
+  codingTool: CodingTool;
+  /** Which ollama-cloud model the wrapper should be pointed at. */
+  ollamaModel: string;
+  prompt: string;
+  runStatus: CliCapabilityRunStatus;
+  resultText: string;
+  rawLogs: string[];
+  message: string;
+  command: string;
+  effectiveModel: string;
+  modelSource: string;
+  runStartedAtMs: number | null;
+  e2eMs: number | null;
+  ttftMs: number | null;
+  tokensPerSec: number | null;
+  exitStatus: number | null;
+  errorType: string;
+  lastRunAt: string | null;
+};
+
+export type StoredCliCapabilityRow = Omit<CliCapabilityRow, 'rawLogs'> & {
+  rawLogs?: string[];
+};
+
+const BASELINE_TOOLS: ReadonlyArray<CodingTool> = ['claude', 'codex', 'opencode', 'copilot'];
+
+function newId(prefix = 'cli-row'): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function defaultModelForBaseline(index: number): string {
+  if (OLLAMA_CLOUD_MODELS.length === 0) return '';
+  return OLLAMA_CLOUD_MODELS[index % OLLAMA_CLOUD_MODELS.length];
+}
+
+function emptyRunFields(): Pick<
+  CliCapabilityRow,
+  | 'runStatus'
+  | 'resultText'
+  | 'rawLogs'
+  | 'message'
+  | 'command'
+  | 'effectiveModel'
+  | 'modelSource'
+  | 'runStartedAtMs'
+  | 'e2eMs'
+  | 'ttftMs'
+  | 'tokensPerSec'
+  | 'exitStatus'
+  | 'errorType'
+  | 'lastRunAt'
+> {
+  return {
+    runStatus: 'idle',
+    resultText: '',
+    rawLogs: [],
+    message: '',
+    command: '',
+    effectiveModel: '',
+    modelSource: '',
+    runStartedAtMs: null,
+    e2eMs: null,
+    ttftMs: null,
+    tokensPerSec: null,
+    exitStatus: null,
+    errorType: '',
+    lastRunAt: null,
+  };
+}
+
+export function createCliCapabilityBaselineRow(
+  codingTool: CodingTool,
+  no: number,
+  ollamaModel?: string,
+): CliCapabilityRow {
+  return {
+    id: `baseline-${codingTool}`,
+    no,
+    isBaseline: true,
+    shouldTest: codingTool !== 'copilot',
+    codingTool,
+    ollamaModel: ollamaModel ?? defaultModelForBaseline(no - 1),
+    prompt: DEFAULT_ADAPTER_TEST_PROMPT,
+    ...emptyRunFields(),
+  };
+}
+
+export function createCustomCliCapabilityRow(
+  no: number,
+  init?: { codingTool?: CodingTool; ollamaModel?: string },
+): CliCapabilityRow {
+  return {
+    id: newId(),
+    no,
+    isBaseline: false,
+    shouldTest: true,
+    codingTool: init?.codingTool ?? TOOL_CONFIGS[0]?.id ?? 'claude',
+    ollamaModel: init?.ollamaModel ?? defaultModelForBaseline(no - 1),
+    prompt: DEFAULT_ADAPTER_TEST_PROMPT,
+    ...emptyRunFields(),
+  };
+}
+
+export function duplicateCliCapabilityRow(row: CliCapabilityRow, no: number): CliCapabilityRow {
+  return {
+    ...row,
+    id: newId('copy'),
+    no,
+    isBaseline: false,
+    shouldTest: true,
+    ...emptyRunFields(),
+  };
+}
+
+export function rowToStored(row: CliCapabilityRow): StoredCliCapabilityRow {
+  // Drop transient logs from local-storage snapshot to keep payload small.
+  const { rawLogs: _rawLogs, ...rest } = row;
+  void _rawLogs;
+  return { ...rest };
+}
+
+function isValidCodingTool(value: unknown): value is CodingTool {
+  return typeof value === 'string' && TOOL_CONFIGS.some((tool) => tool.id === value);
+}
+
+export function fromStoredRows(stored: StoredCliCapabilityRow[]): CliCapabilityRow[] {
+  if (stored.length === 0) {
+    return BASELINE_TOOLS.map((codingTool, index) =>
+      createCliCapabilityBaselineRow(codingTool, index + 1));
+  }
+  return stored.map((row, index) => {
+    const codingTool: CodingTool = isValidCodingTool(row.codingTool) ? row.codingTool : 'claude';
+    const ollamaModel = row.ollamaModel || defaultModelForBaseline(index);
+    return {
+      ...row,
+      no: index + 1,
+      codingTool,
+      ollamaModel,
+      isBaseline: row.id?.startsWith('baseline-') ?? false,
+      shouldTest: row.shouldTest ?? true,
+      prompt: row.prompt || DEFAULT_ADAPTER_TEST_PROMPT,
+      // Reset transient state so a refreshed page never shows a phantom "running" row.
+      runStatus: row.runStatus === 'running' ? 'idle' : row.runStatus,
+      runStartedAtMs: null,
+      rawLogs: [],
+    };
+  });
+}
+
+export function normalizeCliCapabilityRows(rows: CliCapabilityRow[]): CliCapabilityRow[] {
+  return rows.map((row, index) => ({ ...row, no: index + 1 }));
+}

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/cli-eval-tool-config.ts
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/cli-eval-tool-config.ts
@@ -1,0 +1,82 @@
+/**
+ * Mapping of "coding-tool CLIs" we evaluate against ollama-cloud models.
+ *
+ * Execution path: each row is launched via
+ *   `ollama launch <tool> --model <m> --yes -- <tool-headless-args...>`
+ * The actual spawn happens server-side in /api/ai-settings/cli-eval-runs;
+ * this file is purely UI metadata (label, dropdown choices, status badges).
+ *
+ * `status` values come from real terminal TDD against ollama 0.21.1
+ * (2026-05-03):
+ *   - verified   : runs end-to-end with non-empty stdout
+ *   - unverified : known to hang or behave oddly; surface a hint in UI
+ *   - todo       : no headless path yet
+ */
+
+export type CodingTool = 'claude' | 'codex' | 'opencode' | 'copilot';
+
+export type ToolHeadlessStatus = 'verified' | 'unverified' | 'todo';
+
+export type CliEvalToolConfig = {
+  id: CodingTool;
+  label: string;
+  /** Human-readable command preview shown in the UI (the API builds the real argv). */
+  commandPreview: string;
+  status: ToolHeadlessStatus;
+  notes?: string;
+};
+
+export const TOOL_CONFIGS: CliEvalToolConfig[] = [
+  {
+    id: 'claude',
+    label: 'Claude Code',
+    commandPreview: 'ollama launch claude --model <m> --yes -- -p "<prompt>"',
+    status: 'verified',
+  },
+  {
+    id: 'codex',
+    label: 'Codex CLI',
+    commandPreview:
+      'ollama launch codex --model <m> --yes -- exec --oss --local-provider ollama-chat -m <m> "<prompt>"',
+    status: 'verified',
+    notes: 'codex 走 --oss + --local-provider ollama-chat，stdout 每行被 codex 自身格式 prefix。',
+  },
+  {
+    id: 'copilot',
+    label: 'GitHub Copilot CLI',
+    commandPreview: 'ollama launch copilot --model <m> --yes -- -p "<prompt>" --allow-all-tools',
+    status: 'verified',
+    notes: 'copilot 結尾會附 token / 時間統計，不是純粹模型輸出。',
+  },
+  {
+    id: 'opencode',
+    label: 'OpenCode',
+    commandPreview: 'OPENCODE_CONFIG_CONTENT=… opencode run -m ollama/<m> "<prompt>"',
+    status: 'verified',
+    notes: 'opencode 不走 ollama launch wrapper（會 hang），改用 OPENCODE_CONFIG_CONTENT env 直接注入 ollama provider 後 spawn opencode run。',
+  },
+];
+
+/**
+ * Cloud-only ollama models confirmed available on this machine
+ * (verified against `curl http://localhost:11434/api/tags` 2026-05-03).
+ */
+export const OLLAMA_CLOUD_MODELS: string[] = [
+  'kimi-k2.6:cloud',
+  'minimax-m2:cloud',
+  'deepseek-v3.1:671b-cloud',
+  'qwen3-coder:480b-cloud',
+];
+
+export function findToolConfig(id: CodingTool | string): CliEvalToolConfig | null {
+  return TOOL_CONFIGS.find((tool) => tool.id === id) ?? null;
+}
+
+export function pickRandomOllamaModel(currentModel?: string): string {
+  if (OLLAMA_CLOUD_MODELS.length === 0) return currentModel ?? '';
+  if (OLLAMA_CLOUD_MODELS.length === 1) return OLLAMA_CLOUD_MODELS[0];
+  const pool = currentModel
+    ? OLLAMA_CLOUD_MODELS.filter((m) => m !== currentModel)
+    : OLLAMA_CLOUD_MODELS;
+  return pool[Math.floor(Math.random() * pool.length)] ?? OLLAMA_CLOUD_MODELS[0];
+}

--- a/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/page.tsx
+++ b/apps/superadmin/app/superadmin/settings/api_key_and_model_setting/page.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Key, FlaskConical, ScanText, BookMarked, Trophy, Bot,
   Images, Loader2, RefreshCw, Trash2, ShieldCheck, Upload, Download, Play, Route, X,
+  Terminal,
 } from 'lucide-react';
 import {
   PromptManagerModal,
@@ -11,6 +12,7 @@ import {
 } from '@/components/ai-settings/PromptManagerModal';
 
 import { BottomSheetTabs, type SheetTabDef } from '@/components/ui/BottomSheetTabs';
+import { CliCapabilityEvaluationPanel } from './CliCapabilityEvaluationPanel';
 import EnhancedTable from '@/components/ui/EnhancedTable';
 import {
   createAdapterConfigColumns,
@@ -57,6 +59,7 @@ import { evaluateAdapterRun } from './adapter-evaluation';
 
 type SettingsTab =
   | 'keys'
+  | 'cli-capability-evaluation'
   | 'llm-leaderboard'
   | 'evaluations-global'
   | 'evaluations-visual'
@@ -67,6 +70,7 @@ type SettingsTab =
 
 const TAB_IDS: SettingsTab[] = [
   'keys',
+  'cli-capability-evaluation',
   'llm-leaderboard',
   'evaluations-global',
   'evaluations-visual',
@@ -187,6 +191,12 @@ function getTabFromHash(): SettingsTab | null {
 const TABS: { id: SettingsTab; label: string; icon: React.ElementType; description: string }[] = [
   { id: 'keys', label: 'API 金鑰管理', icon: Key, description: '管理各 AI 服務提供商的 API 金鑰' },
   {
+    id: 'cli-capability-evaluation',
+    label: '各家 CLI 能力評測',
+    icon: Terminal,
+    description: '透過本機 CLI（claude / codex / gemini / kilo / opencode / ollama）直接執行 prompt 並比較輸出',
+  },
+  {
     id: 'llm-leaderboard',
     label: 'LLM Leader Board',
     icon: Trophy,
@@ -245,6 +255,14 @@ const EVALUATOR_TAB_CONFIG: Record<string, { hiddenModuleKeys: string[]; statusL
 /** Bottom sheet tab definitions for Excel-style navigation */
 const SHEET_TABS: SheetTabDef[] = [
   { id: 'keys', label: 'API Keys', zhLabel: 'API 金鑰管理', icon: Key, color: 'text-amber-600', activeColor: 'bg-amber-600 text-white' },
+  {
+    id: 'cli-capability-evaluation',
+    label: 'CLI Eval',
+    zhLabel: '各家 CLI 能力評測',
+    icon: Terminal,
+    color: 'text-emerald-700',
+    activeColor: 'bg-emerald-700 text-white',
+  },
   {
     id: 'llm-leaderboard',
     label: 'Leaderboard',
@@ -1920,6 +1938,10 @@ export default function AIServiceSettingsPage() {
       );
     }
 
+    if (activeTab === 'cli-capability-evaluation') {
+      return <CliCapabilityEvaluationPanel />;
+    }
+
     if (activeTab === 'http-adapter-config') {
       const { cli, http } = adapterCompareSummary;
       return (
@@ -2279,6 +2301,7 @@ export default function AIServiceSettingsPage() {
             activeTab !== 'evaluations-global' &&
             activeTab !== 'evaluations-visual' &&
             activeTab !== 'image-to-image-evaluation' &&
+            activeTab !== 'cli-capability-evaluation' &&
             activeTab !== 'http-adapter-config' &&
             activeTab !== 'model-router' && (
             <div className="flex items-center gap-2 shrink-0">


### PR DESCRIPTION
## Summary

- 在 `Settings → API 金鑰管理` 右邊新增 sheet tab「各家 CLI 能力評測 / CLI Eval」，可比較 4 家 coding-tool CLI（Claude Code / Codex / Copilot / OpenCode）配上 ollama cloud 模型在同一 prompt 下的真實輸出。
- 新 API：`POST /api/ai-settings/cli-eval-runs`，spawn CLI、收集 stdout/stderr、含 codex stderr ANSI 抽取邏輯（codex 在 spawn pipe 下把模型輸出寫到 stderr）。
- 4 家 tool 的 headless 路徑已逐一在 terminal + API 端到端 TDD 驗證可拿到非空 stdout：
  - claude → `ollama launch claude --model X --yes -- -p "..."`
  - codex → `ollama launch codex --model X --yes -- exec --oss --local-provider ollama-chat -m X "..."`
  - copilot → `ollama launch copilot --model X --yes -- -p "..." --allow-all-tools`
  - opencode → `OPENCODE_CONFIG_CONTENT=… opencode run -m ollama/X "..."`（繞過 ollama launch wrapper，後者在 headless 下會 hang）

## Files

- 新檔
  - `apps/superadmin/app/api/ai-settings/cli-eval-runs/route.ts`
  - `apps/superadmin/app/superadmin/settings/api_key_and_model_setting/CliCapabilityEvaluationPanel.tsx`
  - `apps/superadmin/app/superadmin/settings/api_key_and_model_setting/cli-capability-evaluation-columns.tsx`
  - `apps/superadmin/app/superadmin/settings/api_key_and_model_setting/cli-capability-row-state.ts`
  - `apps/superadmin/app/superadmin/settings/api_key_and_model_setting/cli-eval-tool-config.ts`
- 修改
  - `apps/superadmin/app/superadmin/settings/api_key_and_model_setting/page.tsx`（加入新 tab 到 `TABS` / `TAB_IDS` / `SHEET_TABS` / `renderContent`）

## Test plan

- [x] Terminal 端逐一 TDD：4 家 CLI 的 headless 命令均拿到非空 stdout
- [x] API 端：`POST /api/ai-settings/cli-eval-runs` 對 claude / codex / copilot / opencode 各跑一次都 `success: true, exitCode: 0`
- [x] UI 端：在 preview 畫面點 row 1 Run 按鈕，row state 從 running → done，row.resultText 拿到模型回覆
- [ ] Reviewer：在本機跑 ollama daemon + 4 家 CLI 已安裝後，於 sheet 點各列 Run 驗證

## 後續可加（不在這個 PR）

- `--pure` flag 給 opencode 跳過外部 plugin（讓模型自介更乾淨）
- `LLM-as-judge` 自動評分欄
- 從 `/api/tags` 動態抓 ollama cloud model 列表

🤖 Generated with [Claude Code](https://claude.com/claude-code)