### PR TITLE
chore(tools): 整合 CodeGraphContext MCP 至開發環境

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@
 - 瀏覽器優先序：專用 MCP → Preview → Playwright CLI → Playwright MCP → Chrome DevTools
 - Playwright CLI（`bash tools/testing/playwright-cli.sh <cmd>`）比 MCP 省 3-5x
 - library 文件用 Context7 MCP，不用 Web Search
+- **CodeGraphContext MCP 已安裝**：查「誰呼叫了 X」、「X 依賴哪些模組」時，優先透過 MCP 查詢圖資料庫，不要 grep 全 repo（省 3–10x token）
 - 完整指南：`docs/operational-guides/token-saving-guide.md`
 
 ## 其他

--- a/docs/operational-guides/token-saving-guide.md
+++ b/docs/operational-guides/token-saving-guide.md
@@ -151,7 +151,47 @@ bash tools/testing/playwright-cli.sh fill e2 "password" --submit
 
 ---
 
-## 7. 實用小技巧
+## 7. CodeGraphContext MCP（Codebase 結構查詢）
+
+CodeGraphContext 已建立本 repo 的程式碼關係圖（869 files、14,359 functions、1,656 classes），並透過 MCP 連線至 Claude Code。
+
+### 何時用 CGC 取代 grep / Read
+
+| 問題類型 | ❌ 舊方式 | ✅ CGC 方式 |
+|:---------|:---------|:-----------|
+| 誰呼叫了某個 function？ | `grep -r "funcName" --include="*.ts"` 多次往返 | MCP query → 直接回傳 caller list |
+| 某 class 被哪些地方繼承？ | Read 多個可能的檔案逐一確認 | MCP query → 繼承關係圖 |
+| 某模組依賴哪些東西？ | 逐一展開 import 追蹤 | `cgc analyze callees <module>` |
+| 有沒有死碼？ | 無法快速判斷 | `cgc analyze dead-code` |
+
+**省 token 原理**：圖資料庫預先解析整個 codebase，一次 MCP call 取代多次 grep + Read 往返，節省 3–10x token。
+
+### 使用方式
+
+**在 Claude Code session 內直接問**（最常用，Claude 自動透過 MCP 查詢）：
+```
+「哪些地方呼叫了 useAuth？」
+「adapter-config.ts 被哪些檔案 import？」
+「找出所有繼承 BaseAdapter 的 class」
+```
+
+**CLI 查詢**（需要精確輸出時）：
+```bash
+cgc analyze callers <functionName>    # 找呼叫者
+cgc analyze callees <functionName>    # 找被呼叫者
+cgc find pattern "useAuth"            # 搜尋 pattern
+cgc analyze dead-code                 # 死碼掃描
+cgc-viz                               # 開啟 http://localhost:18781 互動式圖表
+```
+
+### 限制
+
+- Paperclip worktree 內的異動需重新索引（`cgc index .`）才納入
+- 僅查詢單一 repo，不跨 repo
+
+---
+
+## 8. 實用小技巧
 
 | 技巧 | 說明 |
 |:-----|:-----|
@@ -164,7 +204,7 @@ bash tools/testing/playwright-cli.sh fill e2 "password" --submit
 
 ---
 
-## 8. 總結：省 Token 效果排序
+## 9. 總結：省 Token 效果排序
 
 ```
 🥇 Custom Commands（/daily-report, /commit-push-pr）
@@ -185,6 +225,9 @@ bash tools/testing/playwright-cli.sh fill e2 "password" --submit
 6️⃣ Context7 > Web Search
    → 精準文件片段 > 整頁 HTML
 
-7️⃣ 工具使用小技巧
+7️⃣ CodeGraphContext MCP > grep / Read 全 repo
+   → 圖資料庫直接查關係，省 3–10x token
+
+8️⃣ 工具使用小技巧
    → Read 指定行、Grep 搜尋、批次 tool call
 ```

--- a/start.sh
+++ b/start.sh
@@ -619,6 +619,28 @@ start_hermes_dashboard() {
 
 # --- 啟動函式 ---
 
+start_cgc_viz() {
+    echo -e "${BLUE}🗺️  啟動 CGC 程式碼視覺化 (Port 18781)...${NC}"
+    if ! command -v cgc &> /dev/null; then
+        echo -e "${RED}❌ 找不到 cgc 指令，請確認 CodeGraphContext 已安裝：pipx install codegraphcontext${NC}"
+        return 1
+    fi
+    if lsof -i :18781 > /dev/null 2>&1; then
+        echo -e "${YELLOW}⚠️  CGC Visualizer 已在運行: http://localhost:18781${NC}"
+        return 0
+    fi
+    ensure_log_dir
+    local log_target
+    log_target=$(dev_log_target "$LOG_DIR/cgc-viz.log")
+    nohup cgc visualize --port 18781 > "$log_target" 2>&1 &
+    disown
+    if [ "$log_target" = "/dev/null" ]; then
+        echo -e "${GREEN}✅ CGC Visualizer 啟動成功: http://localhost:18781${NC}"
+    else
+        echo -e "${GREEN}✅ CGC Visualizer 啟動成功: http://localhost:18781, log: $log_target${NC}"
+    fi
+}
+
 start_web() {
     echo -e "${BLUE}🌐 啟動 Web App (Port 3000)...${NC}"
     if lsof -i :3000 > /dev/null 2>&1; then
@@ -893,6 +915,7 @@ start_all() {
     start_paperclip
     start_hermes_dashboard
     start_openclaw "bg"
+    start_cgc_viz
 
     if [ -n "$ELASTIC_WAIT_PID" ]; then
         wait "$ELASTIC_WAIT_PID" 2>/dev/null || true
@@ -910,6 +933,7 @@ start_all() {
     echo -e "   • OpenClaw Dashboard: http://localhost:${openclaw_port}"
     echo -e "   • Supabase Studio:  http://localhost:54323"
     echo -e "   • Mailpit (Email):  http://localhost:54324"
+    echo -e "   • CGC Visualizer:   http://localhost:18781"
     echo -e "   • Logs:             $LOG_DIR/"
     echo -e "   • Hermes data:      $HERMES_HOME_DIR"
     echo -e "   • Paperclip data:   ${PAPERCLIP_DATA_DIR:-$HOME/.paperclip-data-owner-property-management}"
@@ -988,7 +1012,8 @@ show_menu() {
     echo "12) 📊 執行 Observability MVP 檢查"
     echo "13) 🕹️  啟動 OpenClaw"
     echo "14) 💾 備份 Hermes / Paperclip / OpenClaw 資料"
-    echo "15) 🛑 停止所有服務"
+    echo "15) 🗺️  啟動 CGC 程式碼視覺化 (Port 18781)"
+    echo "16) 🛑 停止所有服務"
     echo "0) 離開"
     echo ""
     read -p "請輸入選項: " choice
@@ -1008,7 +1033,8 @@ show_menu() {
         12) run_observability_checks ;;
         13) start_openclaw ;;
         14) backup_agent_data ;;
-        15) ./stop.sh ;;
+        15) start_cgc_viz ;;
+        16) ./stop.sh ;;
         0) exit 0 ;;
         *) echo "無效選項"; sleep 1; show_menu ;;
     esac
@@ -1023,6 +1049,7 @@ case "${1:-menu}" in
     elastic) check_dependencies; start_elasticsearch_stack ;;
     observability) check_dependencies; run_observability_checks ;;
     openclaw) start_openclaw ;;
+    cgc-viz) start_cgc_viz ;;
     backup-agent-data) backup_agent_data ;;
     paperclip) check_dependencies; start_paperclip ;;
     paperclip-update) check_dependencies; update_paperclip_image ;;
@@ -1031,5 +1058,5 @@ case "${1:-menu}" in
     test)   run_tests ;;
     clean)  clean_cache ;;
     menu)   show_menu ;;
-    *)      echo "用法: $0 [all|web|web-au|admin|elastic|observability|openclaw|backup-agent-data|paperclip|paperclip-update|hermes|hermes-update|test|clean|menu]" ;;
+    *)      echo "用法: $0 [all|web|web-au|admin|elastic|observability|openclaw|cgc-viz|backup-agent-data|paperclip|paperclip-update|hermes|hermes-update|test|clean|menu]" ;;
 esac

--- a/stop.sh
+++ b/stop.sh
@@ -79,6 +79,7 @@ elif docker ps -a --format '{{.Names}}' | grep -Eq '^(hermes-opm|hermes-dashboar
 fi
 kill_port 9119 "Hermes Dashboard"
 kill_port 9120 "Hermes Dashboard (Alt Port)"
+kill_port 18781 "CGC Visualizer"
 
 # 停止 Elasticsearch / Kibana Docker 服務
 if [ -f "$ELASTIC_COMPOSE_FILE" ]; then
@@ -103,6 +104,7 @@ rm -f \
     "$LOG_DIR/superadmin.log" \
     "$LOG_DIR/paperclip.log" \
     "$LOG_DIR/hermes-runtime.log" \
+    "$LOG_DIR/cgc-viz.log" \
     /tmp/nextjs.log \
     /tmp/nextjs-au.log \
     /tmp/superadmin.log 2>/dev/null


### PR DESCRIPTION
## Summary

- 安裝 CodeGraphContext v0.4.5（pipx），建立 monorepo 程式碼關係圖索引（869 files、14,359 functions、1,656 classes）
- CGC MCP 以 user scope 全域連線 Claude Code，未來 session 可直接查詢函式/類別關係，取代全 repo grep（省 3–10x token）
- `start.sh` 新增 `start_cgc_viz()`，`./start.sh all` 自動在 port 18781 背景啟動視覺化介面
- `stop.sh` 一併 kill port 18781 並清理 log

## Changes

- **CLAUDE.md**：省 Token 區塊補充 CGC MCP 說明
- **docs/operational-guides/token-saving-guide.md**：新增第 7 節，含使用方式、對比表、限制說明
- **start.sh**：`start_cgc_viz()` 函式、整合進 `start_all`、選單第 15 項、CLI 參數 `cgc-viz`
- **stop.sh**：`kill_port 18781`、清理 `cgc-viz.log`

## Test plan

- [ ] `./start.sh cgc-viz` 啟動後 `curl -s http://localhost:18781/` 回傳 200
- [ ] `./start.sh all` 服務清單顯示 CGC Visualizer port 18781
- [ ] `./stop.sh` 正確 kill port 18781

🤖 Generated with [Claude Code](https://claude.ai/claude-code)