### PR TITLE
feat(project-progress): 隱藏列管理改為 split-button pill

### DIFF
--- a/.claude/rules/general.md
+++ b/.claude/rules/general.md
@@ -72,7 +72,7 @@
 **每次完成工作後**，將成果更新至 `apps/superadmin/app/data/roadmap.ts`（`RAW_FEATURES` 陣列末端新增或修改對應項目）。
 
 - Feature ID 一律以 `apps/superadmin/app/data/roadmap.ts` 內每個 feature 物件的固定 `id` 欄位為準；**不要**用 `RAW_FEATURES` index、table row 順序、或依賴可選欄位（如 `devLogDocPath`、`testScriptPath`）的 regex / parser 估算，否則會把文件掛到錯列。
-- 若 user 已提供 Feature ID / 截圖，先信任該 ID，再核對 `id`、`name`、`testScriptPath`、`devLogDocPath`、`ROADMAP_DATA.lastUpdated` 是否一致。
+- 若 user 已提供 Feature ID / 截圖，先信任該 ID，再核對 `id`、`name`、`testScriptPath`、`devLogDocPath` 是否一致。
 
 ### 必填欄位
 

--- a/apps/superadmin/app/data/roadmap.ts
+++ b/apps/superadmin/app/data/roadmap.ts
@@ -86,7 +86,6 @@ export interface RoadmapFeature {
 }
 
 export interface RoadmapData {
-  lastUpdated: string;
   features: RoadmapFeature[];
 }
 
@@ -2859,7 +2858,6 @@ const RAW_FEATURES: RoadmapFeature[] = [
 ];
 
 export const ROADMAP_DATA: RoadmapData = {
-  lastUpdated: "2026/04/29 Feature ID 084 daily progress report and AI report standardization",
   features: RAW_FEATURES.map((f, index) => ({
     ...f,
     id: normalizeRoadmapFeatureId(f.id) || formatGeneratedRoadmapFeatureId(index),

--- a/apps/superadmin/app/superadmin/dashboard/project-progress/components/development-table/TableToolbar.tsx
+++ b/apps/superadmin/app/superadmin/dashboard/project-progress/components/development-table/TableToolbar.tsx
@@ -81,17 +81,20 @@ export default function TableToolbar({
   const [categoryDropdownOpen, setCategoryDropdownOpen] = useState(false);
   const [alignmentDropdownOpen, setAlignmentDropdownOpen] = useState(false);
   const [viewDropdownOpen, setViewDropdownOpen] = useState(false);
+  const [hiddenRowsPopoverOpen, setHiddenRowsPopoverOpen] = useState(false);
   const [saveWidthsOpen, setSaveWidthsOpen] = useState(false);
   const [alignmentTargetCol, setAlignmentTargetCol] = useState(0);
   const [savePresetName, setSavePresetName] = useState('');
   const categoryDropdownRef = useRef<HTMLDivElement>(null);
   const alignmentDropdownRef = useRef<HTMLDivElement>(null);
   const viewDropdownRef = useRef<HTMLDivElement>(null);
+  const hiddenRowsPopoverRef = useRef<HTMLDivElement>(null);
   const saveWidthsRef = useRef<HTMLDivElement>(null);
   const closeAll = useCallback(() => {
     setCategoryDropdownOpen(false);
     setAlignmentDropdownOpen(false);
     setViewDropdownOpen(false);
+    setHiddenRowsPopoverOpen(false);
     setSaveWidthsOpen(false);
   }, []);
 
@@ -107,6 +110,9 @@ export default function TableToolbar({
       if (viewDropdownOpen && viewDropdownRef.current && !viewDropdownRef.current.contains(target)) {
         setViewDropdownOpen(false);
       }
+      if (hiddenRowsPopoverOpen && hiddenRowsPopoverRef.current && !hiddenRowsPopoverRef.current.contains(target)) {
+        setHiddenRowsPopoverOpen(false);
+      }
       if (saveWidthsOpen && saveWidthsRef.current && !saveWidthsRef.current.contains(target)) {
         setSaveWidthsOpen(false);
       }
@@ -120,7 +126,7 @@ export default function TableToolbar({
       document.removeEventListener('mousedown', handleClick);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [categoryDropdownOpen, alignmentDropdownOpen, viewDropdownOpen, saveWidthsOpen, closeAll]);
+  }, [categoryDropdownOpen, alignmentDropdownOpen, viewDropdownOpen, hiddenRowsPopoverOpen, saveWidthsOpen, closeAll]);
   const handleSavePreset = () => {
     if (!savePresetName.trim()) return;
     onSavePreset(savePresetName.trim());
@@ -279,47 +285,85 @@ export default function TableToolbar({
                     ))}
                   </div>
                 </div>
-                {/* Hidden rows */}
-                <div className="border-t border-border-light mt-1 pt-1">
-                  <div className="px-3 py-1 text-[10px] text-text-muted">Row</div>
-                  <label className="flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-bg-secondary text-sm text-text-primary">
-                    <input
-                      type="checkbox"
-                      checked={showHiddenRows}
-                      onChange={(e) => onShowHiddenRowsChange(e.target.checked)}
-                      className="rounded border-border-default text-emerald-600 focus:ring-emerald-500/20"
-                    />
-                    <span className="truncate">顯示隱藏列 {hiddenRowKeysSet.size > 0 ? `(${hiddenRowKeysSet.size})` : ''}</span>
-                  </label>
-                  {hiddenRowKeysSet.size > 0 && (
-                    <>
-                      <div className="px-3 pb-1">
-                        <button
-                          type="button"
-                          onClick={() => onPatchPrefs({ hiddenRowKeys: [] })}
-                          className="text-xs text-text-secondary hover:text-text-primary"
-                        >
-                          取消所有隱藏
-                        </button>
-                      </div>
-                      <div className="max-h-[240px] overflow-y-auto border-t border-border-light mt-1 pt-1">
-                        {hiddenRowsList.map(({ key, row }) => (
-                          <button
-                            key={key}
-                            type="button"
-                            onClick={() => {
-                              onPatchPrefs({ hiddenRowKeys: [...hiddenRowKeysSet].filter(k => k !== key) });
-                            }}
-                            className="w-full text-left px-3 py-2 text-sm transition-colors text-text-primary hover:bg-bg-secondary"
-                            title="取消隱藏"
-                          >
-                            <span className="block truncate text-xs text-text-muted">{key}</span>
-                            <span className="block truncate">{row ? `${row.__rowId} — ${row.name}` : '（Feature 已不存在）'}</span>
-                          </button>
-                        ))}
-                      </div>
-                    </>
-                  )}
+              </div>
+            )}
+          </div>
+          {/* Hidden rows split-pill: left=toggle checkbox, right=chevron opens popover with list */}
+          <div className="relative" ref={hiddenRowsPopoverRef}>
+            <div
+              className={clsx(
+                'inline-flex items-stretch rounded-full text-xs font-medium border whitespace-nowrap transition-colors overflow-hidden',
+                showHiddenRows
+                  ? 'bg-emerald-50 border-emerald-200 text-emerald-700 dark:bg-emerald-900/30 dark:border-emerald-700 dark:text-emerald-300'
+                  : 'bg-bg-primary border-border-default text-text-secondary'
+              )}
+            >
+              <label
+                className={clsx(
+                  'inline-flex items-center gap-1.5 pl-3 pr-2 py-1.5 cursor-pointer',
+                  !showHiddenRows && 'hover:bg-bg-secondary hover:text-text-primary'
+                )}
+                title="勾選後會顯示已隱藏的 row"
+              >
+                <input
+                  type="checkbox"
+                  checked={showHiddenRows}
+                  onChange={(e) => onShowHiddenRowsChange(e.target.checked)}
+                  className="rounded border-border-default text-emerald-600 focus:ring-emerald-500/20"
+                />
+                <span className="truncate">顯示隱藏列{hiddenRowKeysSet.size > 0 ? ` (${hiddenRowKeysSet.size})` : ''}</span>
+              </label>
+              <button
+                type="button"
+                onClick={() => setHiddenRowsPopoverOpen(open => !open)}
+                aria-expanded={hiddenRowsPopoverOpen}
+                aria-label="管理隱藏列"
+                title="查看 / 個別取消隱藏"
+                disabled={hiddenRowKeysSet.size === 0}
+                className={clsx(
+                  'inline-flex items-center px-2 border-l transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+                  showHiddenRows
+                    ? 'border-emerald-200 dark:border-emerald-700 hover:bg-emerald-100/60 dark:hover:bg-emerald-900/50'
+                    : 'border-border-default hover:bg-bg-secondary hover:text-text-primary'
+                )}
+              >
+                <ChevronDown className={clsx('w-3.5 h-3.5 transition-transform', hiddenRowsPopoverOpen && 'rotate-180')} />
+              </button>
+            </div>
+            {hiddenRowsPopoverOpen && hiddenRowKeysSet.size > 0 && (
+              <div className="absolute left-0 top-full mt-1 z-50 min-w-[260px] bg-bg-primary border border-border-default rounded-lg shadow-lg py-2" role="dialog" aria-label="已隱藏的 Row">
+                <div className="flex items-center justify-between px-3 py-1">
+                  <span className="text-[10px] font-medium text-text-muted uppercase tracking-wide">
+                    已隱藏的 Row ({hiddenRowKeysSet.size})
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onPatchPrefs({ hiddenRowKeys: [] });
+                      setHiddenRowsPopoverOpen(false);
+                    }}
+                    className="text-xs text-text-secondary hover:text-text-primary"
+                  >
+                    取消所有隱藏
+                  </button>
+                </div>
+                <div className="max-h-[280px] overflow-y-auto border-t border-border-light mt-1 pt-1">
+                  {hiddenRowsList.map(({ key, row }) => (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => {
+                        const next = [...hiddenRowKeysSet].filter(k => k !== key);
+                        onPatchPrefs({ hiddenRowKeys: next });
+                        if (next.length === 0) setHiddenRowsPopoverOpen(false);
+                      }}
+                      className="w-full text-left px-3 py-2 text-sm transition-colors text-text-primary hover:bg-bg-secondary"
+                      title="取消隱藏"
+                    >
+                      <span className="block truncate text-xs text-text-muted">{key}</span>
+                      <span className="block truncate">{row ? `${row.__rowId} — ${row.name}` : '（Feature 已不存在）'}</span>
+                    </button>
+                  ))}
                 </div>
               </div>
             )}

--- a/apps/superadmin/app/superadmin/dashboard/project-progress/components/development-table/columns.tsx
+++ b/apps/superadmin/app/superadmin/dashboard/project-progress/components/development-table/columns.tsx
@@ -145,8 +145,8 @@ export function createDevColumns(deps: CreateDevColumnsDeps): ColumnDef<Progress
               aria-label={isHidden ? '顯示 Row' : '隱藏 Row'}
             >
               {isHidden
-                ? <Eye className="w-3.5 h-3.5" />
-                : <EyeOff className="w-3.5 h-3.5" />}
+                ? <EyeOff className="w-3.5 h-3.5" />
+                : <Eye className="w-3.5 h-3.5" />}
             </button>
             {r.__source === 'custom' && (
               <button

--- a/apps/superadmin/app/superadmin/dashboard/project-progress/page.tsx
+++ b/apps/superadmin/app/superadmin/dashboard/project-progress/page.tsx
@@ -177,12 +177,6 @@ export default function ProjectProgressPage() {
             <Activity className="text-emerald-600 w-6 h-6 flex-shrink-0" />
             Project Progress Dashboard (專案進度儀表板)
           </h1>
-          <p className="text-text-secondary text-sm">
-            Track development progress across all modules. Last updated:{' '}
-            <span className="font-mono font-medium text-text-primary">
-              {ROADMAP_DATA.lastUpdated}
-            </span>
-          </p>
         </div>
         <div className="flex items-center gap-3 flex-shrink-0">
           <ExportToVISButton />

--- a/docs/update-project-progress-guide.md
+++ b/docs/update-project-progress-guide.md
@@ -81,7 +81,6 @@ http://localhost:3001/superadmin/dashboard/project-progress#testing
    - `tddSpecDocPath`
    - `docPath`
    - `testScriptPath`
-   - `ROADMAP_DATA.lastUpdated`
    - 以上欄位都不得殘留錯的 Feature ID。
 
 ### 常見錯誤示例
@@ -255,7 +254,7 @@ NODE
 4. **新增或更新項目**
 
    - **更新**：找到對應的 `name` 進行修改
-   - **新增**：在 `RAW_FEATURES` 陣列末尾加入新物件；請同時更新 `ROADMAP_DATA.lastUpdated`（檔案底部）為當日日期
+   - **新增**：在 `RAW_FEATURES` 陣列末尾加入新物件
 5. **必填欄位**：`name`、`category`、`percentage`、`lastModifiedBy`、`lastModifiedDate`
 6. **選填但建議填寫**：`locatedPage`、`featureSpecDocPath`、`tddSpecDocPath`、`docPath`、`e2eTestCoverage`、`devLog`
 7. **建立配套文件與目錄**（每次更新進度時必須檢查）：
@@ -279,7 +278,7 @@ NODE
    2. 建立上述 3 個 `.md` 文件（若已存在則更新內容）
    3. 建立 `unit_test/{Feature-ID}/` 和 `e2e/{Feature-ID}/` 目錄（若已存在則跳過）
    4. 在 roadmap.ts 中填入 `featureSpecDocPath`、`tddSpecDocPath`、`docPath`、`testScriptPath`
-   5. 回讀檢查 `id`、`devLogDocPath`、`testScriptPath`、`ROADMAP_DATA.lastUpdated`，確認沒有掛到別的 Feature ID
+   5. 回讀檢查 `id`、`devLogDocPath`、`testScriptPath`，確認沒有掛到別的 Feature ID
 
    **範例**（Feature ID = 027，備份系統）：
 


### PR DESCRIPTION
## Summary

改善 Project Progress Dashboard 的「隱藏列」管理 UX：

- **TableToolbar**：在 View 旁新增複合 pill `[ ☑ 顯示隱藏列 (N) | ▾ ]`
  - 左半 checkbox：1 click 切換顯示/隱藏全部隱藏列（勾選時整顆 pill 變綠）
  - 右半 chevron：開 popover，列出每個被藏的 row（顯示 `roadmap:NNN` + 名稱），點任一筆即取消那一列的隱藏，另有「取消所有隱藏」連結
  - 無隱藏列時 chevron 自動 disable + opacity 50%
  - 取消最後一筆隱藏後，popover 自動關閉
- **View dropdown**：移除原本「顯示隱藏列」checkbox 與「已隱藏的 Row」清單區塊（避免兩處重複）
- **行內眼睛圖示反轉**（`columns.tsx`）：圖示反映「目前狀態」（可見=Eye 睜眼、隱藏=EyeOff 閉眼），tooltip 仍描述點擊後動作
- **Header 簡化**（`page.tsx`）：移除「Track development progress across all modules. Last updated: …」描述段
- **資料層清理**（`roadmap.ts`）：移除已不被任何 UI 使用的 `RoadmapData.lastUpdated` 型別與資料欄位
- **文件同步**：`docs/update-project-progress-guide.md` 與 `.claude/rules/general.md` 移除已不存在的 `ROADMAP_DATA.lastUpdated` 引用（歷史 dev-log / handoff 紀錄不動）

## Test plan

本機 dev server（worktree 跑在 port 3091）逐項驗證通過：

- [x] checkbox click → 勾選即顯示全部隱藏列 / 取消勾選即隱藏（pill 變綠 ↔ 變灰）
- [x] chevron click → popover 顯示「已隱藏的 ROW (N) / 取消所有隱藏 / 各筆 row 清單」
- [x] popover 內點任一 row → 取消該列隱藏；最後一筆取消後 popover 自動關閉
- [x] 無隱藏列時 chevron disabled
- [x] 點 pill 外部 / Escape 關閉 popover
- [x] View dropdown 已不再含「顯示隱藏列」/「已隱藏的 Row」區塊
- [x] 行內眼睛圖示：可見列 = `eye`、隱藏列 = `eye-off`
- [x] Header 描述段已消失
- [x] TypeScript typecheck 對修改檔案無錯誤
- [x] ESLint 對 TableToolbar.tsx 無新增錯誤（既有 unused-vars warning 與本次無關）

🤖 Generated with [Claude Code](https://claude.com/claude-code)